### PR TITLE
Support chart and table widgets on results page with layout change

### DIFF
--- a/less/components/results.less
+++ b/less/components/results.less
@@ -229,12 +229,13 @@
             }
 
             .vega-embed {
+                max-height: 400px;
                 width: 100%;
                 overflow: auto;
             }
 
             .table-widget {
-                max-height: 500px;
+                max-height: 400px;
                 overflow: auto;
             }
         }

--- a/less/components/results.less
+++ b/less/components/results.less
@@ -210,8 +210,6 @@
         display: flex;
         flex-wrap: wrap;
 
-        margin-bottom: @spacer*2;
-
         .widget {
             background-color: @content-color-background;
             padding: @spacer;

--- a/less/components/results.less
+++ b/less/components/results.less
@@ -28,6 +28,31 @@
         color: @highlight-color;
     }
 
+    .results-actions {
+        display: flex;
+
+        .btn-results {
+            text-transform: none;
+            font-weight: 500;
+            text-decoration: underline;
+            font-size: 1.4em;
+            color: @highlight-color;
+            fill: @highlight-color;
+            padding-left: 0;
+
+            .icon {
+                margin: 0 @spacer/4 0 0;
+            }
+
+            &.recent-queries {
+                .icon {
+                    // This is just to make the dropdown wide!
+                    margin-right: @spacer*20;
+                }
+            }
+        }
+    }
+
     .history-list {
         list-style-type: none;
         padding: 0;
@@ -35,6 +60,8 @@
         color: black;
         border: 1px solid #e9e9e9;
         background-color: @highlight-color-text;
+
+        width: 100%;
 
         max-height: 645px;
         overflow: auto;
@@ -84,20 +111,6 @@
         background-color: @content-color-background;
         margin-bottom: @spacer*3;
         border: 1px solid @light-contrast;
-    }
-
-    .back-button {
-        text-transform: none;
-        font-weight: 500;
-        text-decoration: underline;
-        font-size: 1.4em;
-        color: @highlight-color;
-        fill: @highlight-color;
-        padding-left: 0;
-
-        .icon {
-            margin: 0 @spacer/4 0 0;
-        }
     }
 
     .query-details {
@@ -222,6 +235,15 @@
             .table-widget {
                 max-height: 500px;
                 overflow: auto;
+            }
+        }
+
+        @media (min-width: 1600px) {
+            // .col-xl-* doesn't exist and adding it properly is a lot of work
+            // for something we probably will only use here. Hence a workaround!
+            .col-xl-4-workaround {
+                width: 33.33333333%;
+                float: left;
             }
         }
     }

--- a/less/components/results.less
+++ b/less/components/results.less
@@ -187,6 +187,13 @@
         }
     }
 
+    .widgets {
+        .widget {
+            background-color: @content-color-background;
+            padding: @spacer;
+        }
+    }
+
     .jump-to {
         background-color: @body-background-color;
         position: sticky;

--- a/less/components/results.less
+++ b/less/components/results.less
@@ -213,6 +213,11 @@
                 width: 100%;
                 overflow: auto;
             }
+
+            .table-widget {
+                max-height: 500px;
+                overflow: auto;
+            }
         }
     }
 

--- a/less/components/results.less
+++ b/less/components/results.less
@@ -23,6 +23,7 @@
 
 .results {
     width: 100%;
+    max-width: 1800px;
 
     .results-heading {
         color: @highlight-color;

--- a/less/components/results.less
+++ b/less/components/results.less
@@ -187,6 +187,11 @@
         }
     }
 
+    .widget-heading {
+        color: @highlight-color;
+        margin-bottom: @spacer;
+    }
+
     .widgets {
         display: flex;
         flex-wrap: wrap;

--- a/less/components/results.less
+++ b/less/components/results.less
@@ -198,6 +198,17 @@
             padding: @spacer;
             border: 1px solid @light-contrast;
 
+            &-filter {
+                display: flex;
+                align-items: baseline;
+
+                margin-bottom: @spacer;
+
+                select {
+                    margin-left: @spacer/3;
+                }
+            }
+
             .vega-embed {
                 width: 100%;
                 overflow: auto;

--- a/less/components/results.less
+++ b/less/components/results.less
@@ -191,6 +191,8 @@
         display: flex;
         flex-wrap: wrap;
 
+        margin-bottom: @spacer*2;
+
         .widget {
             background-color: @content-color-background;
             padding: @spacer;

--- a/less/components/results.less
+++ b/less/components/results.less
@@ -215,6 +215,11 @@
             padding: @spacer;
             border: 1px solid @light-contrast;
 
+            &.is-loading {
+                opacity: 0.3;
+                pointer-events: none;
+            }
+
             &-filter {
                 display: flex;
                 align-items: baseline;

--- a/less/components/results.less
+++ b/less/components/results.less
@@ -188,9 +188,18 @@
     }
 
     .widgets {
+        display: flex;
+        flex-wrap: wrap;
+
         .widget {
             background-color: @content-color-background;
             padding: @spacer;
+            border: 1px solid @light-contrast;
+
+            .vega-embed {
+                width: 100%;
+                overflow: auto;
+            }
         }
     }
 

--- a/project.clj
+++ b/project.clj
@@ -61,7 +61,7 @@
                  [com.fzakaria/slf4j-timbre "0.3.19"]
 
                  ; Intermine Assets
-                 [org.intermine/imcljs "1.4.3"]
+                 [org.intermine/imcljs "1.4.4"]
                  [org.intermine/im-tables "0.13.0"]
                  [org.intermine/bluegenes-tool-store "0.2.2"]]
 

--- a/project.clj
+++ b/project.clj
@@ -60,11 +60,6 @@
                  [com.taoensso/timbre "4.10.0"]
                  [com.fzakaria/slf4j-timbre "0.3.19"]
 
-                 ; Graphs
-                 [cljsjs/vega "5.9.0-0"]
-                 [cljsjs/vega-lite "4.0.2-0"]
-                 [cljsjs/vega-embed "6.0.0-0"]
-
                  ; Intermine Assets
                  [org.intermine/imcljs "1.4.3"]
                  [org.intermine/im-tables "0.13.0"]

--- a/src/clj/bluegenes/index.clj
+++ b/src/clj/bluegenes/index.clj
@@ -96,6 +96,10 @@
     [:script {:crossorigin "anonymous"
               :src "https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js"}]
     [:script {:src "https://apis.google.com/js/api.js"}]
+    ;; Graphing library
+    [:script {:src "https://cdn.jsdelivr.net/npm/vega@5.20.2"}]
+    [:script {:src "https://cdn.jsdelivr.net/npm/vega-lite@5.1.0"}]
+    [:script {:src "https://cdn.jsdelivr.net/npm/vega-embed@6.17.0"}]
     (when (:semantic-markup options)
       [:script {:type "application/ld+json"}
        (generate-string (fetch-semantic-markup options))])]))

--- a/src/cljs/bluegenes/components/lighttable.cljs
+++ b/src/cljs/bluegenes/components/lighttable.cljs
@@ -8,6 +8,10 @@
             [imcljs.fetch :as fetch]
             [imcljs.path :as path]))
 
+;; NOTE:
+;; This namespace is not in use. It seems to be an experiment to create a
+;; lighter, less featureful, version of im-tables.
+
 (defn homogeneous-columns
   "Returns a sequence of true / false indicating that all values in each
   column of a table are equal. Assumes all rows are the same length.

--- a/src/cljs/bluegenes/components/table.cljs
+++ b/src/cljs/bluegenes/components/table.cljs
@@ -5,6 +5,11 @@
             [dommy.core :as dommy :refer-macros [sel sel1]]
             [oops.core :refer [ocall oapply oget oset!]]))
 
+;; NOTE:
+;; This namespace is not in use. It seems to be an attempt to use the original
+;; im-tables (not the im-tables-3 ClojureScript clone) within BlueGenes.
+;; Still worth keeping around in case we want to make another try at this.
+
 (defn handle [expanded? e]
   (let [props (reagent/props e)
         node  (sel1 (dom/dom-node e) :.im-target)]

--- a/src/cljs/bluegenes/components/viz/cases.cljs
+++ b/src/cljs/bluegenes/components/viz/cases.cljs
@@ -190,4 +190,5 @@
                                           {:calculate "pow(10, datum.bin_log_x)"
                                            :as "x1"}
                                           {:calculate "pow(10, datum.bin_log_x_end)"
-                                           :as "x2"}])))}]}]])))
+                                           :as "x2"}])))}]}
+        {:class :viz}]])))

--- a/src/cljs/bluegenes/components/viz/common.cljs
+++ b/src/cljs/bluegenes/components/viz/common.cljs
@@ -28,6 +28,11 @@
            (.catch (fn [err]
                      (.warn js/console err))))))))
 
+(def local-keys
+  "Keys that may be passed in opts which we only use in our local implementation.
+  I.e., not intended for consumption by vegaEmbed."
+  [:class])
+
 (defn vega
   "Reagent component that renders vega"
   ([doc] (vega doc {}))
@@ -37,14 +42,15 @@
      (r/create-class
       {:display-name "vega"
        :component-did-mount (fn [this]
-                              (embed-vega (rd/dom-node this) doc opts))
+                              (embed-vega (rd/dom-node this) doc (apply dissoc opts local-keys)))
        :component-did-update (fn [this [_ old-doc old-opts]]
                                (let [[_ new-doc new-opts] (r/argv this)]
                                  (when (or (not= old-doc new-doc)
                                            (not= old-opts new-opts))
-                                   (embed-vega (rd/dom-node this) new-doc new-opts))))
+                                   (embed-vega (rd/dom-node this) new-doc (apply dissoc new-opts local-keys)))))
        :reagent-render (fn []
-                         [:div.viz])}))))
+                         [:div
+                          {:class (:class opts)}])}))))
 
 (defn vega-lite
   "Reagent component that renders vega-lite."

--- a/src/cljs/bluegenes/components/viz/common.cljs
+++ b/src/cljs/bluegenes/components/viz/common.cljs
@@ -20,11 +20,12 @@
   ([elem doc opts]
    (when doc
      (let [doc (clj->js doc)
-           opts (merge {:renderer :canvas
-                        ;; Have to think about how we want the defaults here to behave
-                        :mode "vega-lite"}
-                       opts)]
-       (-> (js/vegaEmbed elem doc (clj->js opts))
+           opts' (merge {:renderer :canvas
+                         ;; Have to think about how we want the defaults here to behave
+                         :mode "vega-lite"}
+                        (dissoc opts :callback))]
+       (-> (js/vegaEmbed elem doc (clj->js opts'))
+           (.then (get opts :callback #()))
            (.catch (fn [err]
                      (.warn js/console err))))))))
 

--- a/src/cljs/bluegenes/components/viz/views.cljs
+++ b/src/cljs/bluegenes/components/viz/views.cljs
@@ -10,11 +10,13 @@
 
 (defn main []
   (let [all-results @(subscribe [:viz/results])]
-    (into [:div]
-          (for [{:keys [viz key]} all-viz]
-            (when-let [results (get all-results key)]
-              ^{:key (name key)}
-              [:div.viz
-               [:div.panel.panel-default
-                [:div.panel-body
-                 [viz results]]]])))))
+    (when (seq all-results)
+      (into [:div
+             [:h3.results-heading "Visualisations"]]
+            (for [{:keys [viz key]} all-viz]
+              (when-let [results (get all-results key)]
+                ^{:key (name key)}
+                [:div.viz
+                 [:div.panel.panel-default
+                  [:div.panel-body
+                   [viz results]]]]))))))

--- a/src/cljs/bluegenes/core.cljs
+++ b/src/cljs/bluegenes/core.cljs
@@ -14,9 +14,6 @@
             [cljsjs.react-transition-group]
             [cljsjs.react-day-picker]
             [cljsjs.react-select]
-            [cljsjs.vega]
-            [cljsjs.vega-lite]
-            [cljsjs.vega-embed]
             [oops.core :refer [ocall]]))
 
 ;(defn dev-setup []

--- a/src/cljs/bluegenes/events.cljs
+++ b/src/cljs/bluegenes/events.cljs
@@ -17,6 +17,7 @@
             [bluegenes.components.search.events]
             [bluegenes.components.navbar.events]
             [bluegenes.pages.results.enrichment.events]
+            [bluegenes.pages.results.widgets.events]
             [bluegenes.components.search.events :as search-full]
             [bluegenes.pages.reportpage.events]
             [bluegenes.pages.querybuilder.events]

--- a/src/cljs/bluegenes/pages/results/enrichment/views.cljs
+++ b/src/cljs/bluegenes/pages/results/enrichment/views.cljs
@@ -33,7 +33,9 @@
   (update-in (js->clj (.parse js/JSON query) :keywordize-keys true) [:where]
              conj {:path path-constraint
                    :op "ONE OF"
-                   :values (cond-> identifier (string? identifier) list)}))
+                   :values (if (coll? identifier)
+                             identifier
+                             (vector identifier))}))
 
 (defn enrichment-result-row []
   (let [current-mine (subscribe [:current-mine-name])]

--- a/src/cljs/bluegenes/pages/results/events.cljs
+++ b/src/cljs/bluegenes/pages/results/events.cljs
@@ -146,7 +146,7 @@
                       im-table-location
                       {:service (merge service {:summary-fields summary-fields})
                        :query value
-                       :settings {:pagination {:limit 25}
+                       :settings {:pagination {:limit 10}
                                   :links {:vocab {:mine (name source)}
                                           :url (fn [{:keys [mine class objectId] :as vocab}]
                                                  (route/href ::route/report
@@ -213,8 +213,7 @@
      ;; two events dispatched below (see TODO above).
      {:db (update db :results assoc
                   :query-parts (clean-query-parts (q/group-views-by-class model query)))
-      :dispatch-n [(when (contains? (get-in db [:env :mines]) (:current-mine db))
-                     [:fetch-ids-tool-entities])
+      :dispatch-n [[:fetch-ids-tool-entities]
                    [:enrichment/enrich]]})))
 
 (reg-event-fx
@@ -250,13 +249,20 @@
                  :value (reduce into results)}
          entities (assoc (get-in db [:tools :entities])
                          class entity)]
-     (cond-> {:db (assoc-in db [:tools :entities] entities)}
+     (cond-> {:db (assoc-in db [:tools :entities] entities)
+              :dispatch-n []}
        ;; If there are no nil values, we know all entities are done fetching
-       ;; and can load the viz/tools. (Tools are loaded through their
+       ;; and can load the viz/tools/widgets. (Tools are loaded through their
        ;; subscription updating when entities-ready? is set.)
        (every? some? (vals entities))
-       (-> (assoc :dispatch [:viz/run-queries])
-           (assoc-in [:db :results :entities-ready?] true))))))
+       (cond->
+        ;; Widgets use the same IDs computed for tools so we don't need to do
+        ;; the operation twice.
+        true (update :dispatch-n conj [:widgets/load])
+        ;; Only load viz and tools if on configured mine.
+        (contains? (get-in db [:env :mines]) (:current-mine db))
+        (-> (update :dispatch-n conj [:viz/run-queries])
+            (assoc-in [:db :results :entities-ready?] true)))))))
 
 (reg-event-db
  :clear-ids-tool-entity

--- a/src/cljs/bluegenes/pages/results/views.cljs
+++ b/src/cljs/bluegenes/pages/results/views.cljs
@@ -48,9 +48,11 @@
   (let [historical-queries (subscribe [:results/historical-queries])
         current-query (subscribe [:results/history-index])]
     (fn []
-      [:div
-       [:h3 [:i.fa.fa-clock-o] " Recent Queries"]
-       (into [:ul.history-list]
+      [:div.dropdown
+       [:button.btn.btn-link.btn-results.recent-queries.dropdown-toggle
+        {:data-toggle "dropdown"}
+        "Recent Queries" [icon "caret-down"]]
+       (into [:ul.dropdown-menu.history-list]
              (map (fn [[title {:keys [source value display-title] :as query}]]
                     [:li.history-item
                      {:class (when (= title @current-query) "active")
@@ -116,7 +118,7 @@
 
 (defn back-button []
   (let [intent @(subscribe [:results/intent])]
-    [:button.btn.btn-link.back-button
+    [:button.btn.btn-link.btn-results
      {:on-click #(dispatch (case intent
                              :query [::route/navigate ::route/querybuilder]
                              :search [::route/navigate ::route/search]
@@ -137,7 +139,8 @@
         {:keys [size authorized timestamp type tags
                 description] :as list} @(subscribe [:results/current-list])]
     [:div.query-details
-     {:title "Use the Edit button on the Lists page to change details"}
+     (when list
+       {:title "Use the Edit button on the Lists page to change details"})
      [:div.query-or-list
       [:span.query-title title]
       (when list ; You won't have this data if it's an unsaved query.
@@ -193,20 +196,18 @@
        (when @are-there-results?
          [:<>
           [:div.row
-           [:div.col-sm-3.col-lg-2
-            [query-history]
-            [:div.hidden-lg
-             [enrichment/enrich]]]
-           [:div.col-sm-9.col-lg-7
+           [:div.col-sm-8.col-lg-9
             [:h2.results-heading "Query Results"]
-            [back-button]
-             ;; Query details is only interesting if it's a saved list.
+            [:div.results-actions
+             [back-button]
+             [query-history]]
+            ;; Query details is only interesting if it's a saved list.
             (when (= @intent :list)
               [query-details])
             [:div.results-table
              [tables/main [:results :table]]]
             [widgets/main]]
-           [:div.col-sm-3.visible-lg-block
+           [:div.col-sm-4.col-lg-3
             [enrichment/enrich]]]
           ;; Only show visualizations for configured mines (i.e. not registry mines).
           (when @current-mine-is-env?

--- a/src/cljs/bluegenes/pages/results/views.cljs
+++ b/src/cljs/bluegenes/pages/results/views.cljs
@@ -5,6 +5,7 @@
             [bluegenes.pages.results.events]
             [bluegenes.pages.results.subs]
             [bluegenes.pages.results.enrichment.views :as enrichment]
+            [bluegenes.pages.results.widgets.views :as widgets]
             [bluegenes.components.bootstrap :refer [popover tooltip]]
             [clojure.string :refer [split]]
             [oops.core :refer [oget oget+ ocall oset!]]
@@ -203,7 +204,8 @@
             (when (= @intent :list)
               [query-details])
             [:div.results-table
-             [tables/main [:results :table]]]]
+             [tables/main [:results :table]]]
+            [widgets/main]]
            [:div.col-sm-3.visible-lg-block
             [enrichment/enrich]]]
           ;; Only show visualizations for configured mines (i.e. not registry mines).

--- a/src/cljs/bluegenes/pages/results/views.cljs
+++ b/src/cljs/bluegenes/pages/results/views.cljs
@@ -175,15 +175,17 @@
 (defn jump-to []
   (let [tool-names (map :names @(subscribe [:bluegenes.components.tools.subs/suitable-tools]))]
     (when (seq tool-names)
-      (into [:div.jump-to
-             [:span "Jump to: "]
-             [:span.jump-item
-              {:on-click #(scroll-into-view! nil)}
-              "Top"]]
-            (for [{:keys [cljs human]} tool-names]
+      [:<>
+       [:h3.results-heading "Tools"]
+       (into [:div.jump-to
+              [:span "Jump to: "]
               [:span.jump-item
-               {:on-click #(scroll-into-view! (str cljs "-container"))}
-               (clean-tool-name human)])))))
+               {:on-click #(scroll-into-view! nil)}
+               "Top"]]
+             (for [{:keys [cljs human]} tool-names]
+               [:span.jump-item
+                {:on-click #(scroll-into-view! (str cljs "-container"))}
+                (clean-tool-name human)]))])))
 
 (defn main
   "Result page for a list or query."
@@ -213,6 +215,6 @@
           (when @current-mine-is-env?
             [:div.row
              [:div.col-sm-12
-              [jump-to]
               [viz/main]
+              [jump-to]
               [tools/main]]])])])))

--- a/src/cljs/bluegenes/pages/results/widgets/events.cljs
+++ b/src/cljs/bluegenes/pages/results/widgets/events.cljs
@@ -1,0 +1,55 @@
+(ns bluegenes.pages.results.widgets.events
+  (:require [re-frame.core :refer [reg-event-db reg-event-fx]]
+            [clojure.string :as str]
+            [clojure.set :as set]
+            [imcljs.fetch :as im-fetch]))
+
+;; Enrichment widgets are handled in their own namespace.
+(def supported-widget-types #{"chart" "table"})
+
+(defn get-widget-targets
+  [widget]
+  (->> widget :targets (map keyword)))
+
+(defn widgets-to-load
+  [entities widgets]
+  (filter (fn [widget]
+            (and (contains? supported-widget-types (:widgetType widget))
+                 (some entities (get-widget-targets widget))))
+          widgets))
+
+(defn mapify-widgets
+  [widgets]
+  (reduce #(assoc %1 (:name %2) %2) {} widgets))
+
+(reg-event-fx
+ :widgets/load
+ (fn [{db :db} [_]]
+   (let [entities (get-in db [:tools :entities])
+         widgets (widgets-to-load entities (get-in db [:assets :widgets (:current-mine db)]))]
+     {:dispatch-n (map (fn [widget]
+                         [:widgets/get-widget-data widget (:value (some entities (get-widget-targets widget)))])
+                       widgets)})))
+
+(reg-event-fx
+ :widgets/get-widget-data
+ (fn [{db :db} [_ widget ids]]
+   (let [fetch-widget (case (:widgetType widget)
+                        "chart" im-fetch/chart-widget
+                        "table" im-fetch/table-widget)
+         widget-name (:name widget)
+         service (get-in db [:mines (:current-mine db) :service])]
+     {:im-chan {:chan (fetch-widget service "Public ABC Genes (testing)" widget-name)
+                :on-success [:widgets/get-widget-data-success widget-name]
+                :on-failure [:widgets/get-widget-data-failure widget-name]}})))
+
+(reg-event-db
+ :widgets/get-widget-data-success
+ (fn [db [_ widget-name res]]
+   (assoc-in db [:results :widget-results (keyword widget-name)] res)))
+
+(reg-event-fx
+ :widgets/get-widget-data-failure
+ (fn [{db :db} [_ widget-name res]]
+   {:db (assoc-in db [:results :widget-results (keyword widget-name)] false)
+    :log-error [(str "Failed to get " widget-name " data") res]}))

--- a/src/cljs/bluegenes/pages/results/widgets/events.cljs
+++ b/src/cljs/bluegenes/pages/results/widgets/events.cljs
@@ -55,3 +55,8 @@
  (fn [{db :db} [_ widget-name res]]
    {:db (assoc-in db [:results :widget-results (keyword widget-name)] false)
     :log-error [(str "Failed to get " widget-name " data") res]}))
+
+(reg-event-db
+ :widgets/reset
+ (fn [db]
+   (update-in db [:results :widget-results] empty)))

--- a/src/cljs/bluegenes/pages/results/widgets/events.cljs
+++ b/src/cljs/bluegenes/pages/results/widgets/events.cljs
@@ -44,7 +44,7 @@
                         "table" im-fetch/table-widget)
          widget-name (:name widget)
          service (get-in db [:mines (:current-mine db) :service])]
-     {:im-chan {:chan (fetch-widget service ids widget-name type options)
+     {:im-chan {:chan (fetch-widget service ids widget-name (assoc options :type type))
                 :on-success [:widgets/get-widget-data-success widget-name]
                 :on-failure [:widgets/get-widget-data-failure widget-name]}})))
 

--- a/src/cljs/bluegenes/pages/results/widgets/events.cljs
+++ b/src/cljs/bluegenes/pages/results/widgets/events.cljs
@@ -65,7 +65,8 @@
    (let [entities (get-in db [:tools :entities])
          widget (some #(when (= widget-kw (keyword (:name %))) %)
                       (get-in db [:assets :widgets (:current-mine db)]))]
-     {:dispatch (widget->event entities widget {:filter value})})))
+     {:db (update-in db [:results :widget-results widget-kw] assoc :loading? true)
+      :dispatch (widget->event entities widget {:filter value})})))
 
 (reg-event-db
  :widgets/reset

--- a/src/cljs/bluegenes/pages/results/widgets/events.cljs
+++ b/src/cljs/bluegenes/pages/results/widgets/events.cljs
@@ -39,6 +39,7 @@
                         "table" im-fetch/table-widget)
          widget-name (:name widget)
          service (get-in db [:mines (:current-mine db) :service])]
+     ;; TODO DEBUG
      {:im-chan {:chan (fetch-widget service "Public ABC Genes (testing)" widget-name)
                 :on-success [:widgets/get-widget-data-success widget-name]
                 :on-failure [:widgets/get-widget-data-failure widget-name]}})))

--- a/src/cljs/bluegenes/pages/results/widgets/events.cljs
+++ b/src/cljs/bluegenes/pages/results/widgets/events.cljs
@@ -28,19 +28,20 @@
    (let [entities (get-in db [:tools :entities])
          widgets (widgets-to-load entities (get-in db [:assets :widgets (:current-mine db)]))]
      {:dispatch-n (map (fn [widget]
-                         [:widgets/get-widget-data widget (:value (some entities (get-widget-targets widget)))])
+                         (let [{:keys [class value]}
+                               (some entities (get-widget-targets widget))]
+                           [:widgets/get-widget-data widget value class]))
                        widgets)})))
 
 (reg-event-fx
  :widgets/get-widget-data
- (fn [{db :db} [_ widget ids]]
+ (fn [{db :db} [_ widget ids type]]
    (let [fetch-widget (case (:widgetType widget)
                         "chart" im-fetch/chart-widget
                         "table" im-fetch/table-widget)
          widget-name (:name widget)
          service (get-in db [:mines (:current-mine db) :service])]
-     ;; TODO DEBUG
-     {:im-chan {:chan (fetch-widget service "Public ABC Genes (testing)" widget-name)
+     {:im-chan {:chan (fetch-widget service ids widget-name type)
                 :on-success [:widgets/get-widget-data-success widget-name]
                 :on-failure [:widgets/get-widget-data-failure widget-name]}})))
 

--- a/src/cljs/bluegenes/pages/results/widgets/subs.cljs
+++ b/src/cljs/bluegenes/pages/results/widgets/subs.cljs
@@ -1,0 +1,7 @@
+(ns bluegenes.pages.results.widgets.subs
+  (:require [re-frame.core :refer [reg-sub]]))
+
+(reg-sub
+ :widgets/all-widgets
+ (fn [db]
+   (get-in db [:results :widget-results])))

--- a/src/cljs/bluegenes/pages/results/widgets/views.cljs
+++ b/src/cljs/bluegenes/pages/results/widgets/views.cljs
@@ -264,25 +264,27 @@
 
 (defn main []
   (let [widgets @(subscribe [:widgets/all-widgets])]
-    [:div.widgets
-     ;; Uncomment me to test the PieChart!
-     #_[piechart {:chartType "PieChart",
-                  :description "Percentage of employees belonging to each company",
-                  :type "Employee",
-                  :list "Everyones-Favourite-Employees",
-                  :title "Company Affiliation",
-                  :rangeLabel "No. of employees",
-                  :notAnalysed 0,
-                  :results [["No. of employees"]
-                            ["Capitol Versicherung AG" 5]
-                            ["Dunder-Mifflin" 1]
-                            ["Wernham-Hogg" 1]]}]
-     (doall (for [[widget-kw widget-data] widgets
-                  :let [widget-comp (case (:chartType widget-data)
-                                      ("BarChart" "ColumnChart") chart
-                                      "PieChart" piechart
-                                      ;; If chartType is missing, it's a table widget.
-                                      table)
-                        full-width? (= (count widgets) 1)]]
-              ^{:key widget-kw}
-              [widget-comp widget-kw widget-data :full-width? full-width?]))]))
+    [:div
+     [:h3.widget-heading "Widgets"]
+     [:div.widgets
+      ;; Uncomment me to test the PieChart!
+      #_[piechart {:chartType "PieChart",
+                   :description "Percentage of employees belonging to each company",
+                   :type "Employee",
+                   :list "Everyones-Favourite-Employees",
+                   :title "Company Affiliation",
+                   :rangeLabel "No. of employees",
+                   :notAnalysed 0,
+                   :results [["No. of employees"]
+                             ["Capitol Versicherung AG" 5]
+                             ["Dunder-Mifflin" 1]
+                             ["Wernham-Hogg" 1]]}]
+      (doall (for [[widget-kw widget-data] (sort-by (comp str/lower-case :title val) widgets)
+                   :let [widget-comp (case (:chartType widget-data)
+                                       ("BarChart" "ColumnChart") chart
+                                       "PieChart" piechart
+                                       ;; If chartType is missing, it's a table widget.
+                                       table)
+                         full-width? (= (count widgets) 1)]]
+               ^{:key widget-kw}
+               [widget-comp widget-kw widget-data :full-width? full-width?]))]]))

--- a/src/cljs/bluegenes/pages/results/widgets/views.cljs
+++ b/src/cljs/bluegenes/pages/results/widgets/views.cljs
@@ -275,7 +275,7 @@
 
 (defn main []
   (let [widgets @(subscribe [:widgets/all-widgets])
-        widgets (sort-by (comp str/lower-case :title val)
+        widgets (sort-by key
                          ;; Value is false if it failed, which we won't show.
                          (filter val widgets))]
     (when (seq widgets)

--- a/src/cljs/bluegenes/pages/results/widgets/views.cljs
+++ b/src/cljs/bluegenes/pages/results/widgets/views.cljs
@@ -92,8 +92,8 @@
      [vega-lite
       {:description description
        :height (case chartType
-                "BarChart" {:step 8}
-                "ColumnChart" nil)
+                 "BarChart" {:step 8}
+                 "ColumnChart" nil)
        :data {:values values}
        :mark {:type "bar"
               :cursor "pointer"}

--- a/src/cljs/bluegenes/pages/results/widgets/views.cljs
+++ b/src/cljs/bluegenes/pages/results/widgets/views.cljs
@@ -22,7 +22,7 @@
                         values child
                         widget-kw]}]
   (conj [:div.widget.col-sm-12
-         {:class (when-not full-width? :col-md-6)}
+         {:class (when-not full-width? [:col-lg-6 :col-xl-4-workaround])}
          [:h4 title]
          [:p {:dangerouslySetInnerHTML {:__html description}}]
          (if (pos? notAnalysed)

--- a/src/cljs/bluegenes/pages/results/widgets/views.cljs
+++ b/src/cljs/bluegenes/pages/results/widgets/views.cljs
@@ -173,6 +173,8 @@
     (fn [widget-kw data & {:keys [full-width?]}]
       (let [{:keys [title description notAnalysed type columns pathQuery pathConstraint columnTitle]
              values :results} data
+            ;; Uncomment me to see a tall table!
+            ; values (take 20 (cycle values))
             current-mine @(subscribe [:current-mine-name])
             all-identifiers (mapv :identifier values)]
         [widget
@@ -193,39 +195,40 @@
                                                     (vec @selected))
                                      :title (table-query-title title columnTitle)})}
            (if (empty? @selected) "View All" "View Selected")]
-          [:table.table.table-condensed.table-striped
-           [:thead
-            (into [:tr
-                   (let [all-identifiers-set (set all-identifiers)
-                         is-checked (= @selected all-identifiers-set)
-                         on-check (if is-checked
-                                    #(swap! selected empty)
-                                    #(reset! selected all-identifiers-set))]
-                     [:th
-                      [:input {:type "checkbox"
-                               :checked is-checked
-                               :on-click on-check}]])]
-                  (for [col-header (str/split columns #",")]
-                    [:th col-header]))]
-           (into [:tbody]
-                 (for [row values]
-                   (into [:tr]
-                         (let [{:keys [identifier descriptions matches]} row
-                               is-checked (contains? @selected identifier)
-                               on-check #(swap! selected (if is-checked disj conj) identifier)]
-                           (concat
-                            [[:td
-                              [:input {:type "checkbox"
-                                       :checked is-checked
-                                       :on-click on-check}]]]
-                            (map (fn [desc] [:td desc]) descriptions)
-                            [[:td
-                              [:a {:on-click #(view-items! {:current-mine current-mine
-                                                            :pathQuery pathQuery
-                                                            :pathConstraint pathConstraint
-                                                            :identifiers identifier
-                                                            :title (table-query-title title columnTitle)})}
-                               matches]]])))))]]]))))
+          [:div.table-widget
+           [:table.table.table-condensed.table-striped
+            [:thead
+             (into [:tr
+                    (let [all-identifiers-set (set all-identifiers)
+                          is-checked (= @selected all-identifiers-set)
+                          on-check (if is-checked
+                                     #(swap! selected empty)
+                                     #(reset! selected all-identifiers-set))]
+                      [:th
+                       [:input {:type "checkbox"
+                                :checked is-checked
+                                :on-click on-check}]])]
+                   (for [col-header (str/split columns #",")]
+                     [:th col-header]))]
+            (into [:tbody]
+                  (for [row values]
+                    (into [:tr]
+                          (let [{:keys [identifier descriptions matches]} row
+                                is-checked (contains? @selected identifier)
+                                on-check #(swap! selected (if is-checked disj conj) identifier)]
+                            (concat
+                             [[:td
+                               [:input {:type "checkbox"
+                                        :checked is-checked
+                                        :on-click on-check}]]]
+                             (map (fn [desc] [:td desc]) descriptions)
+                             [[:td
+                               [:a {:on-click #(view-items! {:current-mine current-mine
+                                                             :pathQuery pathQuery
+                                                             :pathConstraint pathConstraint
+                                                             :identifiers identifier
+                                                             :title (table-query-title title columnTitle)})}
+                                matches]]])))))]]]]))))
 
 (defn main []
   (let [widgets @(subscribe [:widgets/all-widgets])]

--- a/src/cljs/bluegenes/pages/results/widgets/views.cljs
+++ b/src/cljs/bluegenes/pages/results/widgets/views.cljs
@@ -268,28 +268,32 @@
                                 matches]]])))))]]]]))))
 
 (defn main []
-  (let [widgets @(subscribe [:widgets/all-widgets])]
-    [:div
-     [:h3.widget-heading "Widgets"]
-     [:div.widgets
-      ;; Uncomment me to test the PieChart!
-      #_[piechart :test-piechart {:chartType "PieChart",
-                                  :description "Percentage of employees belonging to each company",
-                                  :type "Employee",
-                                  :list "Everyones-Favourite-Employees",
-                                  :title "Company Affiliation",
-                                  :rangeLabel "No. of employees",
-                                  :notAnalysed 0,
-                                  :results [["No. of employees"]
-                                            ["Capitol Versicherung AG" 5]
-                                            ["Dunder-Mifflin" 1]
-                                            ["Wernham-Hogg" 1]]}]
-      (doall (for [[widget-kw widget-data] (sort-by (comp str/lower-case :title val) widgets)
-                   :let [widget-comp (case (:chartType widget-data)
-                                       ("BarChart" "ColumnChart") chart
-                                       "PieChart" piechart
-                                       ;; If chartType is missing, it's a table widget.
-                                       table)
-                         full-width? (= (count widgets) 1)]]
-               ^{:key widget-kw}
-               [widget-comp widget-kw widget-data :full-width? full-width?]))]]))
+  (let [widgets @(subscribe [:widgets/all-widgets])
+        widgets (sort-by (comp str/lower-case :title val)
+                         ;; Value is false if it failed, which we won't show.
+                         (filter val widgets))]
+    (when (seq widgets)
+      [:div
+       [:h3.widget-heading "Widgets"]
+       [:div.widgets
+        ;; Uncomment me to test the PieChart!
+        #_[piechart :test-piechart {:chartType "PieChart",
+                                    :description "Percentage of employees belonging to each company",
+                                    :type "Employee",
+                                    :list "Everyones-Favourite-Employees",
+                                    :title "Company Affiliation",
+                                    :rangeLabel "No. of employees",
+                                    :notAnalysed 0,
+                                    :results [["No. of employees"]
+                                              ["Capitol Versicherung AG" 5]
+                                              ["Dunder-Mifflin" 1]
+                                              ["Wernham-Hogg" 1]]}]
+        (doall (for [[widget-kw widget-data] widgets
+                     :let [widget-comp (case (:chartType widget-data)
+                                         ("BarChart" "ColumnChart") chart
+                                         "PieChart" piechart
+                                         ;; If chartType is missing, it's a table widget.
+                                         table)
+                           full-width? (= (count widgets) 1)]]
+                 ^{:key widget-kw}
+                 [widget-comp widget-kw widget-data :full-width? full-width?]))]])))

--- a/src/cljs/bluegenes/pages/results/widgets/views.cljs
+++ b/src/cljs/bluegenes/pages/results/widgets/views.cljs
@@ -4,6 +4,18 @@
             [clojure.string :as str]
             [inflections.core :refer [plural]]))
 
+(defn widget [& {:keys [title description notAnalysed type values child]}]
+  (conj [:div.widget.col-sm-12.col-md-6
+         [:h4 title]
+         [:p {:dangerouslySetInnerHTML {:__html description}}]
+         (if (pos? notAnalysed)
+           [:p (str "Number of " (plural type) " in the table not analysed in this widget: ")
+            [:strong notAnalysed]]
+           [:p (str "All " (plural type) " in the table have been analysed in this widget.")])]
+        (if (seq values)
+          child
+          [:p.failure (str "No results.")])))
+
 (defn chart [data]
   (let [{:keys [title description domainLabel rangeLabel chartType notAnalysed seriesLabels type]
          [labels & tuples] :results} data
@@ -15,121 +27,120 @@
                               (rest labels)
                               all-series))
                        tuples)]
-    [:div.widget.col-sm-12.col-md-6
-     [:h4 title]
-     [:p {:dangerouslySetInnerHTML {:__html description}}]
-     (if (pos? notAnalysed)
-       [:p (str "Number of " (plural type) " in the table not analysed in this widget: ")
-        [:strong notAnalysed]]
-       [:p (str "All " (plural type) " in the table have been analysed in this widget.")])
-     (if (seq values)
-       [vega-lite
-        {:description description
-         ; :width "container"
-         :height {:step 8}
-         ; :autosize {:type "fit-x"
-         ;            :contains "padding"}
-         :data {:values values}
-         :mark "bar"
-         :encoding {(case chartType
-                      "BarChart" :row
-                      "ColumnChart" :column)
-                    {:field "domain"
-                     :type "nominal"
-                     :spacing 2
-                     :title domainLabel
-                     :header
-                     (case chartType
-                       "BarChart"
-                       {:labelAngle 0
-                        :labelAlign "left"
-                        :labelOrient "left"
-                        :labelLimit 100}
-                       "ColumnChart"
-                       {:labelAngle 45
-                        :labelAlign "left"
-                        :labelOrient "bottom"
-                        :titleOrient "bottom"
-                        :labelLimit 100})}
+    [widget
+     :title title
+     :description description
+     :notAnalysed notAnalysed
+     :type type
+     :values values
+     :child
+     [vega-lite
+      {:description description
+       ; :width "container"
+       :height {:step 8}
+       ; :autosize {:type "fit-x"
+       ;            :contains "padding"}
+       :data {:values values}
+       :mark "bar"
+       :encoding {(case chartType
+                    "BarChart" :row
+                    "ColumnChart" :column)
+                  {:field "domain"
+                   :type "nominal"
+                   :spacing 2
+                   :title domainLabel
+                   :header
+                   (case chartType
+                     "BarChart"
+                     {:labelAngle 0
+                      :labelAlign "left"
+                      :labelOrient "left"
+                      :labelLimit 100}
+                     "ColumnChart"
+                     {:labelAngle 45
+                      :labelAlign "left"
+                      :labelOrient "bottom"
+                      :titleOrient "bottom"
+                      :labelLimit 100})}
 
-                    (case chartType
-                      "BarChart" :x
-                      "ColumnChart" :y)
-                    {:field "value"
-                     :type "quantitative"
-                     :title rangeLabel
-                     :axis {:tickMinStep 1}}
+                  (case chartType
+                    "BarChart" :x
+                    "ColumnChart" :y)
+                  {:field "value"
+                   :type "quantitative"
+                   :title rangeLabel
+                   :axis {:tickMinStep 1}}
 
-                    (case chartType
-                      "BarChart" :y
-                      "ColumnChart" :x)
-                    {:field "type"
-                     :type "nominal"
-                     :title nil
-                     :sort (str/split seriesLabels #",")
-                     :axis {:labels false
-                            :ticks false}}
+                  (case chartType
+                    "BarChart" :y
+                    "ColumnChart" :x)
+                  {:field "type"
+                   :type "nominal"
+                   :title nil
+                   :sort (str/split seriesLabels #",")
+                   :axis {:labels false
+                          :ticks false}}
 
-                    :color {:field "type"
-                            :type "nominal"
-                            :title nil
-                            :scale {:domain (str/split seriesLabels #",")
-                                    :scheme "category20"}
-                            :legend {:direction "horizontal"
-                                     :orient "top"}}
+                  :color {:field "type"
+                          :type "nominal"
+                          :title nil
+                          :scale {:domain (str/split seriesLabels #",")
+                                  :scheme "category20"}
+                          :legend {:direction "horizontal"
+                                   :orient "top"}}
 
-                    :tooltip [{:field "domain"
-                               :type "nominal"}
-                              {:field "type"
-                               :type "nominal"}
-                              {:field "value"
-                               :type "quantitative"}]}}]
-       [:p.failure (str "No results.")])]))
+                  :tooltip [{:field "domain"
+                             :type "nominal"}
+                            {:field "type"
+                             :type "nominal"}
+                            {:field "value"
+                             :type "quantitative"}]}}]]))
 
 (defn piechart [data]
   (let [{:keys [title description notAnalysed type rangeLabel]
          [_ & tuples] :results} data
         values (map #(zipmap [:category :value] %) tuples)]
-    [:div.widget.col-sm-12.col-md-6
-     [:h4 title]
-     [:p {:dangerouslySetInnerHTML {:__html description}}]
-     (if (pos? notAnalysed)
-       [:p (str "Number of " (plural type) " in the table not analysed in this widget: ")
-        [:strong notAnalysed]]
-       [:p (str "All " (plural type) " in the table have been analysed in this widget.")])
-     (if (seq values)
-       [vega-lite
-        {:description description
-         :title rangeLabel
-         :data {:values values}
-         :encoding {:theta {:field "value" :type "quantitative" :stack true}
-                    :color {:field "category"
-                            :type "nominal"
-                            :legend {:title nil}
-                            :scale {:scheme "category20c"}}}
-         :layer [{:mark {:type "arc" :outerRadius 120}
-                  :encoding {:tooltip [{:field "category" :type "nominal"}
-                                       {:field "value" :type "quantitative"}]}}
-                 {:mark {:type "text" :radius 100 :fill "white"}
-                  :encoding {:text {:field "value" :type "nominal"}}}]
-         :view {:stroke nil}}]
-       [:p.failure (str "No results.")])]))
+    [widget
+     :title title
+     :description description
+     :notAnalysed notAnalysed
+     :type type
+     :values values
+     :child
+     [vega-lite
+      {:description description
+       :title rangeLabel
+       :data {:values values}
+       :encoding {:theta {:field "value" :type "quantitative" :stack true}
+                  :color {:field "category"
+                          :type "nominal"
+                          :legend {:title nil}
+                          :scale {:scheme "category20c"}}}
+       :layer [{:mark {:type "arc" :outerRadius 120}
+                :encoding {:tooltip [{:field "category" :type "nominal"}
+                                     {:field "value" :type "quantitative"}]}}
+               {:mark {:type "text" :radius 100 :fill "white"}
+                :encoding {:text {:field "value" :type "nominal"}}}]
+       :view {:stroke nil}}]]))
 
 (defn table [data]
-  [:h4 (:title data)])
-
-(defn widget [data]
-  (case (:chartType data)
-    ("BarChart" "ColumnChart") [chart data]
-    "PieChart" [piechart data]
-    ;; If chartType is missing, it's a table widget.
-    [table data]))
+  (let [{:keys [title description notAnalysed type]
+         values :results} data]
+    [widget
+     :title title
+     :description description
+     :notAnalysed notAnalysed
+     :type type
+     :values values
+     :child
+     ;; TODO make table widget
+     [:pre (pr-str values)]]))
 
 (defn main []
   (let [widgets @(subscribe [:widgets/all-widgets])]
     [:div.widgets
      ;; Uncomment me to test the PieChart!
-     #_[widget {:chartType "PieChart",
+     [piechart {:chartType "PieChart",
                 :description "Percentage of employees belonging to each company",
                 :type "Employee",
                 :list "Everyones-Favourite-Employees",
@@ -140,6 +151,11 @@
                           ["Capitol Versicherung AG" 5]
                           ["Dunder-Mifflin" 1]
                           ["Wernham-Hogg" 1]]}]
-     (doall (for [[widget-kw widget-data] widgets]
+     (doall (for [[widget-kw widget-data] widgets
+                  :let [widget-comp (case (:chartType widget-data)
+                                      ("BarChart" "ColumnChart") chart
+                                      "PieChart" piechart
+                                      ;; If chartType is missing, it's a table widget.
+                                      table)]]
               ^{:key widget-kw}
-              [widget widget-data]))]))
+              [widget-comp widget-data]))]))

--- a/src/cljs/bluegenes/pages/results/widgets/views.cljs
+++ b/src/cljs/bluegenes/pages/results/widgets/views.cljs
@@ -1,9 +1,10 @@
 (ns bluegenes.pages.results.widgets.views
   (:require [re-frame.core :refer [subscribe]]
-            [bluegenes.components.viz.common :refer [vega-lite]]))
+            [bluegenes.components.viz.common :refer [vega-lite]]
+            [clojure.string :as str]))
 
 (defn chart [data]
-  (let [{:keys [title description domainLabel rangeLabel]
+  (let [{:keys [title description domainLabel rangeLabel chartType notAnalysed seriesLabels]
          [labels & tuples] :results} data
         values (mapcat (fn [[domain & all-series]]
                          (map (fn [label value]
@@ -13,53 +14,82 @@
                               (rest labels)
                               all-series))
                        tuples)]
-    [:div.widget.col-sm-6
+    [:div.widget.col-sm-12.col-md-6
      [:h4 title]
-     [:p description]
-     [vega-lite
-      (doto
-       {:description description
-        ; :width "container"
-        :height {:step 8}
-        ; :autosize {:type "fit-x"
-        ;            :contains "padding"}
-        :data {:values values}
-        :mark {:type "bar"}
-        :encoding {:row {:field "domain"
-                         :type "nominal"
-                         :spacing 2
-                         :title domainLabel
-                         :header {:labelAngle 0
-                                  :labelAlign "left"
-                                  :labelOrient "left"
-                                  :labelLimit 100}}
-                   :x {:field "value"
-                       :type "quantitative"
-                       :title rangeLabel
-                       :axis {:tickMinStep 1}}
-                   :y {:field "type"
-                       :type "nominal"
-                       :title nil
-                       :axis {:labels false
-                              :ticks false}}
-                   :color {:field "type"
-                           :type "nominal"
-                           :title nil}
-                   :tooltip [{:field "domain"
-                              :type "nominal"}
-                             {:field "type"
-                              :type "nominal"}
-                             {:field "value"
-                              :type "quantitative"}]}}
-       js/console.log)]]))
+     [:p {:dangerouslySetInnerHTML {:__html description}}]
+     (when (pos? notAnalysed)
+       [:p "Number of Genes in the table not analysed in this widget: "
+        [:strong notAnalysed]])
+     (if (seq values)
+       [vega-lite
+        {:description description
+         ; :width "container"
+         :height {:step 8}
+         ; :autosize {:type "fit-x"
+         ;            :contains "padding"}
+         :data {:values values}
+         :mark "bar"
+         :encoding {(case chartType
+                      "BarChart" :row
+                      "ColumnChart" :column)
+                    {:field "domain"
+                     :type "nominal"
+                     :spacing 2
+                     :title domainLabel
+                     :header
+                     (case chartType
+                       "BarChart"
+                       {:labelAngle 0
+                        :labelAlign "left"
+                        :labelOrient "left"
+                        :labelLimit 100}
+                       "ColumnChart"
+                       {:labelAngle 45
+                        :labelAlign "left"
+                        :labelOrient "bottom"
+                        :titleOrient "bottom"
+                        :labelLimit 100})}
+
+                    (case chartType
+                      "BarChart" :x
+                      "ColumnChart" :y)
+                    {:field "value"
+                     :type "quantitative"
+                     :title rangeLabel
+                     :axis {:tickMinStep 1}}
+
+                    (case chartType
+                      "BarChart" :y
+                      "ColumnChart" :x)
+                    {:field "type"
+                     :type "nominal"
+                     :title nil
+                     :sort (str/split seriesLabels #",")
+                     :axis {:labels false
+                            :ticks false}}
+
+                    :color {:field "type"
+                            :type "nominal"
+                            :title nil
+                            :scale {:domain (str/split seriesLabels #",")
+                                    :range {:scheme "category20"}}
+                            :legend {:direction "horizontal"
+                                     :orient "top"}}
+
+                    :tooltip [{:field "domain"
+                               :type "nominal"}
+                              {:field "type"
+                               :type "nominal"}
+                              {:field "value"
+                               :type "quantitative"}]}}]
+       [:p.failure (str "No results.")])]))
 
 (defn table [data]
   [:h4 (:title data)])
 
 (defn widget [data]
   (cond
-    (and (= (:title data) "Gene Expression in the Fly (FlyAtlas)") ;; TODO DEBUG
-         (:chartType data)) [chart data]
+    (:chartType data) [chart data]
     :else [table data]))
 
 (defn main []

--- a/src/cljs/bluegenes/pages/results/widgets/views.cljs
+++ b/src/cljs/bluegenes/pages/results/widgets/views.cljs
@@ -1,0 +1,70 @@
+(ns bluegenes.pages.results.widgets.views
+  (:require [re-frame.core :refer [subscribe]]
+            [bluegenes.components.viz.common :refer [vega-lite]]))
+
+(defn chart [data]
+  (let [{:keys [title description domainLabel rangeLabel]
+         [labels & tuples] :results} data
+        values (mapcat (fn [[domain & all-series]]
+                         (map (fn [label value]
+                                {:domain domain
+                                 :type label
+                                 :value value})
+                              (rest labels)
+                              all-series))
+                       tuples)]
+    [:div.widget.col-sm-6
+     [:h4 title]
+     [:p description]
+     [vega-lite
+      (doto
+       {:description description
+        ; :width "container"
+        :height {:step 8}
+        ; :autosize {:type "fit-x"
+        ;            :contains "padding"}
+        :data {:values values}
+        :mark {:type "bar"}
+        :encoding {:row {:field "domain"
+                         :type "nominal"
+                         :spacing 2
+                         :title domainLabel
+                         :header {:labelAngle 0
+                                  :labelAlign "left"
+                                  :labelOrient "left"
+                                  :labelLimit 100}}
+                   :x {:field "value"
+                       :type "quantitative"
+                       :title rangeLabel
+                       :axis {:tickMinStep 1}}
+                   :y {:field "type"
+                       :type "nominal"
+                       :title nil
+                       :axis {:labels false
+                              :ticks false}}
+                   :color {:field "type"
+                           :type "nominal"
+                           :title nil}
+                   :tooltip [{:field "domain"
+                              :type "nominal"}
+                             {:field "type"
+                              :type "nominal"}
+                             {:field "value"
+                              :type "quantitative"}]}}
+       js/console.log)]]))
+
+(defn table [data]
+  [:h4 (:title data)])
+
+(defn widget [data]
+  (cond
+    (and (= (:title data) "Gene Expression in the Fly (FlyAtlas)") ;; TODO DEBUG
+         (:chartType data)) [chart data]
+    :else [table data]))
+
+(defn main []
+  (let [widgets @(subscribe [:widgets/all-widgets])]
+    [:div.widgets
+     (doall (for [[widget-kw widget-data] widgets]
+              ^{:key widget-kw}
+              [widget widget-data]))]))

--- a/src/cljs/bluegenes/pages/results/widgets/views.cljs
+++ b/src/cljs/bluegenes/pages/results/widgets/views.cljs
@@ -91,7 +91,9 @@
      :child
      [vega-lite
       {:description description
-       :height {:step 8}
+       :height (case chartType
+                "BarChart" {:step 8}
+                "ColumnChart" nil)
        :data {:values values}
        :mark {:type "bar"
               :cursor "pointer"}

--- a/src/cljs/bluegenes/pages/results/widgets/views.cljs
+++ b/src/cljs/bluegenes/pages/results/widgets/views.cljs
@@ -19,10 +19,12 @@
 
 (defn widget [& {:keys [title description full-width? notAnalysed type
                         filterSelectedValue filters filterLabel
-                        values child
+                        loading? values child
                         widget-kw]}]
   (conj [:div.widget.col-sm-12
-         {:class (when-not full-width? [:col-lg-6 :col-xl-4-workaround])}
+         {:class (-> []
+                     (into (when-not full-width? [:col-lg-6 :col-xl-4-workaround]))
+                     (into (when loading? [:is-loading])))}
          [:h4 title]
          [:p {:dangerouslySetInnerHTML {:__html description}}]
          (if (pos? notAnalysed)
@@ -59,7 +61,8 @@
 
 (defn chart [widget-kw data & {:keys [full-width?]}]
   (let [{:keys [title description domainLabel rangeLabel chartType notAnalysed seriesValues seriesLabels type pathQuery
-                filterSelectedValue filters filterLabel]
+                filterSelectedValue filters filterLabel
+                loading?]
          [labels & tuples] :results} data
         values (mapcat (fn [[domain & all-series]]
                          (map (fn [label value]
@@ -83,6 +86,7 @@
      :filterSelectedValue filterSelectedValue
      :filters filters
      :filterLabel filterLabel
+     :loading? loading?
      :values values
      :child
      [vega-lite
@@ -163,7 +167,8 @@
 
 (defn piechart [widget-kw data & {:keys [full-width?]}]
   (let [{:keys [title description notAnalysed type rangeLabel
-                filterSelectedValue filters filterLabel]
+                filterSelectedValue filters filterLabel
+                loading?]
          [_ & tuples] :results} data
         values (map #(zipmap [:category :value] %) tuples)]
     [widget
@@ -176,6 +181,7 @@
      :filterSelectedValue filterSelectedValue
      :filters filters
      :filterLabel filterLabel
+     :loading? loading?
      :values values
      :child
      [vega-lite

--- a/src/cljs/bluegenes/pages/results/widgets/views.cljs
+++ b/src/cljs/bluegenes/pages/results/widgets/views.cljs
@@ -1,10 +1,11 @@
 (ns bluegenes.pages.results.widgets.views
   (:require [re-frame.core :refer [subscribe]]
             [bluegenes.components.viz.common :refer [vega-lite]]
-            [clojure.string :as str]))
+            [clojure.string :as str]
+            [inflections.core :refer [plural]]))
 
 (defn chart [data]
-  (let [{:keys [title description domainLabel rangeLabel chartType notAnalysed seriesLabels]
+  (let [{:keys [title description domainLabel rangeLabel chartType notAnalysed seriesLabels type]
          [labels & tuples] :results} data
         values (mapcat (fn [[domain & all-series]]
                          (map (fn [label value]
@@ -18,7 +19,7 @@
      [:h4 title]
      [:p {:dangerouslySetInnerHTML {:__html description}}]
      (when (pos? notAnalysed)
-       [:p "Number of Genes in the table not analysed in this widget: "
+       [:p (str "Number of " (plural type) " in the table not analysed in this widget: ")
         [:strong notAnalysed]])
      (if (seq values)
        [vega-lite

--- a/src/cljs/bluegenes/pages/results/widgets/views.cljs
+++ b/src/cljs/bluegenes/pages/results/widgets/views.cljs
@@ -26,7 +26,9 @@
                                  :value value})
                               (rest labels)
                               all-series))
-                       tuples)]
+                       tuples ; Replace with below to see how it looks with more items.
+                       #_(concat tuples
+                                 (map #(update % 0 str " 2") tuples)))]
     [widget
      :title title
      :description description
@@ -36,10 +38,7 @@
      :child
      [vega-lite
       {:description description
-       ; :width "container"
        :height {:step 8}
-       ; :autosize {:type "fit-x"
-       ;            :contains "padding"}
        :data {:values values}
        :mark "bar"
        :encoding {(case chartType

--- a/src/cljs/bluegenes/pages/results/widgets/views.cljs
+++ b/src/cljs/bluegenes/pages/results/widgets/views.cljs
@@ -118,7 +118,12 @@
                   {:field "value"
                    :type "quantitative"
                    :title rangeLabel
-                   :axis {:tickMinStep 1}}
+                   :axis (case chartType
+                           "BarChart"
+                           {:tickMinStep 1
+                            :orient "top"}
+                           "ColumnChart"
+                           {:tickMinStep 1})}
 
                   (case chartType
                     "BarChart" :y
@@ -268,17 +273,17 @@
      [:h3.widget-heading "Widgets"]
      [:div.widgets
       ;; Uncomment me to test the PieChart!
-      #_[piechart {:chartType "PieChart",
-                   :description "Percentage of employees belonging to each company",
-                   :type "Employee",
-                   :list "Everyones-Favourite-Employees",
-                   :title "Company Affiliation",
-                   :rangeLabel "No. of employees",
-                   :notAnalysed 0,
-                   :results [["No. of employees"]
-                             ["Capitol Versicherung AG" 5]
-                             ["Dunder-Mifflin" 1]
-                             ["Wernham-Hogg" 1]]}]
+      #_[piechart :test-piechart {:chartType "PieChart",
+                                  :description "Percentage of employees belonging to each company",
+                                  :type "Employee",
+                                  :list "Everyones-Favourite-Employees",
+                                  :title "Company Affiliation",
+                                  :rangeLabel "No. of employees",
+                                  :notAnalysed 0,
+                                  :results [["No. of employees"]
+                                            ["Capitol Versicherung AG" 5]
+                                            ["Dunder-Mifflin" 1]
+                                            ["Wernham-Hogg" 1]]}]
       (doall (for [[widget-kw widget-data] (sort-by (comp str/lower-case :title val) widgets)
                    :let [widget-comp (case (:chartType widget-data)
                                        ("BarChart" "ColumnChart") chart

--- a/src/cljs/bluegenes/route.cljs
+++ b/src/cljs/bluegenes/route.cljs
@@ -222,6 +222,7 @@
                  ;; previous invocation. This way, we'll only show the new
                  ;; results and tools once they're ready.
                  (dispatch [:results/clear])
+                 (dispatch [:widgets/reset])
                  (dispatch [:clear-ids-tool-entity])
                  (dispatch [:viz/clear])
                  (dispatch [:set-active-panel :results-panel

--- a/src/cljs/bluegenes/route.cljs
+++ b/src/cljs/bluegenes/route.cljs
@@ -277,6 +277,9 @@
   ;; - Put side-effects you want to run on every page load/change here!
   ;; Make sure there are no hanging popovers.
   (ocall (js/$ ".popover") "remove")
+  ;; When clicking a bar in a vega-lite chart, it shows the results in a new
+  ;; page and the tooltip lingers.
+  (ocall (js/$ "#vg-tooltip-element") "remove")
   ;; Track the page (new-match has :data, so can use anything from `routes`).
   (try
     (js/ga "send" "pageview" (:path new-match))

--- a/src/cljs/bluegenes/subs.cljs
+++ b/src/cljs/bluegenes/subs.cljs
@@ -12,6 +12,7 @@
             [bluegenes.pages.lists.subs]
             [bluegenes.pages.tools.subs]
             [bluegenes.pages.developer.subs]
+            [bluegenes.pages.results.widgets.subs]
             [bluegenes.version :as version]
             [bluegenes.utils :as utils]
             [lambdaisland.uri :refer [uri]]


### PR DESCRIPTION
This PR adds [chart and table widgets](http://intermine.org/im-docs/docs/webapp/lists/list-widgets/index/) to the query results/list analysis page.

When looking further into enrichment widgets in #713, we noticed that there wasn't much of a hurdle to adding the remaining types of widgets to Bluegenes. This would complement the Tool API as a lightweight, more constrained alternative.

This made the results page more busy, which necessitated a change to the layout. With feedback from the team, the lefthand *Recent Queries* panel has been moved into a dropdown below the header.

Note that this will require https://github.com/intermine/imcljs/pull/55 which also depends on changes to InterMine list widget web services to support the passing of object IDs instead of list name (in a coming InterMine minor/patch release). Older Intermine servers without this change will simply error out the widget request, causing the widget to not display and logging an error to console.
