### PR TITLE
Downloading of enrichment results

### DIFF
--- a/less/site.less
+++ b/less/site.less
@@ -529,6 +529,24 @@ textarea.hidden-clipboard {
     }
 }
 
+.btn.btn-icon {
+    padding: @spacer/4;
+    outline: 0;
+    fill: #eee;
+
+    .icon {
+        margin: 0;
+    }
+
+    &:hover {
+        outline: 0;
+    }
+
+    &:active {
+        outline: 0;
+    }
+}
+
 .top-scroll {
     position:sticky;
     right:10px;

--- a/src/cljs/bluegenes/effects.cljs
+++ b/src/cljs/bluegenes/effects.cljs
@@ -351,4 +351,5 @@
      (oset! a :download filename)
      (ocall js/document.body :appendChild a)
      (ocall a :click)
-     (ocall js/window.URL :revokeObjectURL url))))
+     (ocall js/window.URL :revokeObjectURL url)
+     (ocall js/document.body :removeChild a))))

--- a/src/cljs/bluegenes/effects.cljs
+++ b/src/cljs/bluegenes/effects.cljs
@@ -5,7 +5,8 @@
             [cljs-http.client :as http]
             [cognitect.transit :as t]
             [bluegenes.titles :refer [db->title]]
-            [oops.core :refer [ocall oget]]
+            [bluegenes.utils :refer [encode-file]]
+            [oops.core :refer [ocall oget oset!]]
             [goog.dom :as gdom]
             [goog.style :as gstyle]
             [goog.fx.dom :as gfx]))
@@ -336,3 +337,18 @@
  :change-route
  (fn [new-path]
    (.replaceState js/window.history nil "" (str "/" new-path))))
+
+;; filename - string including extension
+;; filetype - string to be appended to 'text/' forming a mime type
+;; data     - string representing the contents of the file
+(reg-fx
+ :download-file
+ (fn [{:keys [filename filetype data]}]
+   (let [a (ocall js/document :createElement "a")
+         url (encode-file data filetype)]
+     (oset! a [:style :display] "none")
+     (oset! a :href url)
+     (oset! a :download filename)
+     (ocall js/document.body :appendChild a)
+     (ocall a :click)
+     (ocall js/window.URL :revokeObjectURL url))))

--- a/src/cljs/bluegenes/pages/reportpage/views.cljs
+++ b/src/cljs/bluegenes/pages/reportpage/views.cljs
@@ -170,10 +170,12 @@
   (let [id           (subscribe [::subs/fasta-identifier])
         fasta        (subscribe [::subs/fasta])
         download-ref (atom nil)
-        download!    #(let [el @download-ref]
-                        (ocall el :setAttribute "href" (encode-file @fasta "fasta"))
+        download!    #(let [el @download-ref
+                            url (encode-file @fasta "fasta")]
+                        (ocall el :setAttribute "href" url)
                         (ocall el :setAttribute "download" (str @id ".fasta"))
-                        (ocall el :click))]
+                        (ocall el :click)
+                        (ocall js/window.URL :revokeObjectURL url))]
     (fn []
       [:<>
        [:a.hidden-download {:download "download" :ref (fn [el] (reset! download-ref el))}]

--- a/src/cljs/bluegenes/pages/reportpage/views.cljs
+++ b/src/cljs/bluegenes/pages/reportpage/views.cljs
@@ -16,6 +16,7 @@
             [bluegenes.components.icons :refer [icon icon-comp]]
             [clojure.string :as str]
             [bluegenes.components.bootstrap :refer [poppable]]
+            [bluegenes.utils :refer [encode-file]]
             [oops.core :refer [ocall oget]]
             [goog.functions :refer [debounce]]))
 
@@ -164,14 +165,6 @@
      {:on-click #(dispatch [::events/open-in-region-search value])}
      [poppable {:data "Perform a search of this region"
                 :children value}]]]])
-
-(defn encode-file
-  "Encode a stringified text file such that it can be downloaded by the browser.
-  Results must be stringified - don't pass objects / vectors / arrays / whatever."
-  [data filetype]
-  (ocall js/URL "createObjectURL"
-         (js/Blob. (clj->js [data])
-                   {:type (str "text/" filetype)})))
 
 (defn fasta-download []
   (let [id           (subscribe [::subs/fasta-identifier])

--- a/src/cljs/bluegenes/pages/results/enrichment/events.cljs
+++ b/src/cljs/bluegenes/pages/results/enrichment/events.cljs
@@ -10,7 +10,9 @@
   (update-in (js->clj (.parse js/JSON query) :keywordize-keys true) [:where]
              conj {:path path-constraint
                    :op "ONE OF"
-                   :values [identifier]}))
+                   :values (if (coll? identifier)
+                             (vec identifier)
+                             (vector identifier))}))
 
 (reg-event-fx
  :enrichment/get-item-details
@@ -208,3 +210,64 @@
                  (or (get-in res [:body :error])
                      (str "Failed to get enrichment results for " widget-name)))
        (assoc-in [:results :enrichment-results-loading?] false))))
+
+(reg-event-fx
+ :enrichment/view-one-result
+ (fn [{db :db} [_ details identifier]]
+   (let [query (assoc (build-matches-query (:pathQuery details) (:pathConstraint details) identifier)
+                      :title identifier)]
+     {:dispatch [:results/history+
+                 {:source (:current-mine db)
+                  :type :query
+                  :intent :enrichment
+                  :value query}]})))
+
+(reg-event-fx
+ :enrichment/view-results
+ (fn [{db :db} [_ details identifiers]]
+   (let [query (assoc (build-matches-query (:pathQuery details) (:pathConstraint details) identifiers)
+                      :title "Enrichment Results")]
+     {:dispatch [:results/history+
+                 {:source (:current-mine db)
+                  :type :query
+                  :intent :enrichment
+                  :value query}]})))
+
+(reg-event-fx
+ :enrichment/download-results
+ (fn [{db :db} [_ details identifiers]]
+   (let [query (build-matches-query (:pathQueryForMatches details) (:pathConstraint details) identifiers)]
+     {:im-chan {:chan (fetch/rows (service db (:current-mine db)) query)
+                :on-success [:enrichment/download-results-enriched details identifiers]
+                :on-failure [:enrichment/notify-failed-download (:title details)]}})))
+
+(reg-event-fx
+ :enrichment/notify-failed-download
+ (fn [{db :db} [_ widget-title]]
+   {:dispatch [:messages/add
+               {:markup [:span (str "Failed to download results for " widget-title)]
+                :style "danger"}]}))
+
+(defn get-active-query-title [db]
+  (let [query (get-in db [:results :queries
+                          (get-in db [:results :history-index])])]
+    (or (:display-title query)
+        (get-in query [:value :title]))))
+
+(reg-event-fx
+ :enrichment/download-results-enriched
+ (fn [{db :db} [_ widget-details selected-identifiers {:keys [results]}]]
+   (if (empty? results)
+     {:dispatch [:enrichment/notify-failed-download (:title widget-details)]}
+     (let [selected-identifier? (set selected-identifiers)
+           identifier->result (group-by first results)
+           query-title (get-active-query-title db)]
+       {:download
+        [(str query-title " " (:title widget-details))
+         (->> (:results widget-details)
+              (filter (comp selected-identifier? :identifier))
+              (map (fn [{:keys [identifier p-value description]}]
+                     (string/join \tab [description p-value
+                                        (string/join "," (->> identifier identifier->result (map second)))
+                                        identifier])))
+              (string/join \newline))]}))))

--- a/src/cljs/bluegenes/pages/results/enrichment/events.cljs
+++ b/src/cljs/bluegenes/pages/results/enrichment/events.cljs
@@ -262,12 +262,13 @@
      (let [selected-identifier? (set selected-identifiers)
            identifier->result (group-by first results)
            query-title (get-active-query-title db)]
-       {:download
-        [(str query-title " " (:title widget-details))
-         (->> (:results widget-details)
-              (filter (comp selected-identifier? :identifier))
-              (map (fn [{:keys [identifier p-value description]}]
-                     (string/join \tab [description p-value
-                                        (string/join "," (->> identifier identifier->result (map second)))
-                                        identifier])))
-              (string/join \newline))]}))))
+       {:download-file
+        {:filename (str query-title " " (:title widget-details) ".tsv")
+         :filetype "tab-separated-values"
+         :data (->> (:results widget-details)
+                    (filter (comp selected-identifier? :identifier))
+                    (map (fn [{:keys [identifier p-value description]}]
+                           (string/join \tab [description p-value
+                                              (string/join "," (->> identifier identifier->result (map second)))
+                                              identifier])))
+                    (string/join \newline))}}))))

--- a/src/cljs/bluegenes/pages/results/widgets/views.cljs
+++ b/src/cljs/bluegenes/pages/results/widgets/views.cljs
@@ -5,7 +5,7 @@
             [clojure.string :as str]
             [inflections.core :refer [plural]]
             [oops.core :refer [oget ocall]]
-            [bluegenes.pages.results.enrichment.views :refer [build-matches-query]]))
+            [bluegenes.pages.results.enrichment.events :refer [build-matches-query]]))
 
 (defn filter-display [& {:keys [widget-kw filterSelectedValue filters filterLabel]}]
   (let [filters (str/split filters #",")]

--- a/src/cljs/bluegenes/utils.cljs
+++ b/src/cljs/bluegenes/utils.cljs
@@ -302,7 +302,10 @@
 
 (defn encode-file
   "Encode a stringified text file such that it can be downloaded by the browser.
-  Results must be stringified - don't pass objects / vectors / arrays / whatever."
+  Results must be stringified - don't pass objects / vectors / arrays / whatever.
+  Ideally for performance, you'll want to invoke
+      (ocall js/window.URL :revokeObjectURL url)
+  where `url` is what's returned by this function, once you're done using it."
   [data filetype]
   (ocall js/URL "createObjectURL"
          (js/Blob. (clj->js [data])

--- a/src/cljs/bluegenes/utils.cljs
+++ b/src/cljs/bluegenes/utils.cljs
@@ -6,7 +6,8 @@
             [bluegenes.version :as version]
             [bluegenes.components.icons :refer [icon]]
             [markdown-to-hiccup.core :as md]
-            [goog.string :as gstring]))
+            [goog.string :as gstring]
+            [oops.core :refer [ocall]]))
 
 (defn hiccup-anchors-newtab
   "Add target=_blank to all anchor elements, so all links open in new tabs."
@@ -298,3 +299,11 @@
     (mapv (fn [result]
             (zipmap views result))
           (:results res))))
+
+(defn encode-file
+  "Encode a stringified text file such that it can be downloaded by the browser.
+  Results must be stringified - don't pass objects / vectors / arrays / whatever."
+  [data filetype]
+  (ocall js/URL "createObjectURL"
+         (js/Blob. (clj->js [data])
+                   {:type (str "text/" filetype)})))


### PR DESCRIPTION
Adds a download button (icon due to little space) for each enrichment widget, to download all or selected enrichment results, to a file identical to the one the legacy webapp provided.

Closes #728
