### PR TITLE
Show mines incompatible with BG as external links

### DIFF
--- a/config/defaults/config.edn
+++ b/config/defaults/config.edn
@@ -13,6 +13,7 @@
                               ;  :root "https://www.humanmine.org/humanmine"
                               ;  :name "HumanMine"
                               ;  :namespace "humanmine"
+                              ;  ; :external true ; Optional to open as a new tab.
                               ;  }
                               ]
  :hide-registry-mines false

--- a/less/components/home.less
+++ b/less/components/home.less
@@ -358,7 +358,7 @@
                     }
                 }
 
-                button {
+                a, button {
                     height: @mine-entry-height;
                     font-size: 1.1em;
                     font-weight: bold;

--- a/less/components/navbar.less
+++ b/less/components/navbar.less
@@ -157,6 +157,10 @@
                         text-align: left;
                         font-size: 1.2em;
                     }
+
+                    .icon {
+                        fill: @body-foreground-color;
+                    }
                 }
             }
         }

--- a/less/components/report.less
+++ b/less/components/report.less
@@ -385,6 +385,11 @@
                     display: inline-block;
                     white-space: normal;
                     margin-right: @spacer/2;
+
+                    .icon {
+                        margin-left: @spacer/4;
+                        fill: @visible-gray;
+                    }
                 }
 
                 img {

--- a/src/cljs/bluegenes/components/navbar/nav.cljs
+++ b/src/cljs/bluegenes/components/navbar/nav.cljs
@@ -11,7 +11,8 @@
             [clojure.string :as str]
             [bluegenes.config :refer [read-default-ns]]
             [bluegenes.components.bootstrap :refer [poppable]]
-            [bluegenes.components.icons :refer [icon]]))
+            [bluegenes.components.icons :refer [icon]]
+            [bluegenes.utils :refer [get-mine-url]]))
 
 (def ^:const logo-path "/model/images/logo.png")
 
@@ -208,7 +209,7 @@
      {:title desc})
    [:a (cond
          current? {:class "current"}
-         external? {:target "_blank" :href (:url details)}
+         external? {:target "_blank" :href (get-mine-url details)}
          :else {:href (route/href ::route/home {:mine mine-key})})
     [mine-icon details]
     (str (:name details)
@@ -228,7 +229,7 @@
                            ^{:key mine-key}
                            [mine-entry mine-key details
                             :current? (= mine-key current-mine-name)
-                            :external? external?])
+                            :external? (or external? (:external? details))])
                          (sort-by (comp :name val) mines)))]
     [:li.minename.mine-settings.dropdown.primary-nav
      [:a.dropdown-toggle {:data-toggle "dropdown" :role "button"}

--- a/src/cljs/bluegenes/components/navbar/nav.cljs
+++ b/src/cljs/bluegenes/components/navbar/nav.cljs
@@ -16,6 +16,12 @@
 
 (def ^:const logo-path "/model/images/logo.png")
 
+;; This logo is banned! It's just the InterMine logo, and some mines
+;; have it set as /branding:images.logo while they have a proper logo
+;; under `logo-path`. I'll just sneak it in here and everything will
+;; look nice :-)
+(def ignore-logo-path "https://cdn.rawgit.com/intermine/design-materials/78a13db5/logos/intermine/squareish/45x45.png")
+
 (defn mine-icon
   "returns the icon set for a specific mine, or a default.
    Pass it the entire set of mine details, e.g.
@@ -23,9 +29,14 @@
   [details & {:keys [class]}]
   [:img
    {:class class
-    :src (or (get-in details [:images :logo]) ; Path when it's from registry.
-             (get-in details [:branding :images :logo]) ; Path when it's the current mine.
-             (str (get-in details [:service :root]) logo-path))}]) ; Fallback path.
+    :src
+    (let [branding-path (or (get-in details [:images :logo]) ; Path when it's from registry.
+                            (get-in details [:branding :images :logo])) ; Path when it's the current mine.
+          fallback-path (str (get-mine-url details) logo-path)] ; Fallback path.
+      (if (or (empty? branding-path)
+              (= branding-path ignore-logo-path))
+        fallback-path
+        branding-path))}])
 
 (defn update-form [atom key evt]
   (swap! atom assoc key (oget evt :target :value)))

--- a/src/cljs/bluegenes/components/navbar/nav.cljs
+++ b/src/cljs/bluegenes/components/navbar/nav.cljs
@@ -9,7 +9,9 @@
             [bluegenes.components.icons :refer [icon-comp]]
             [bluegenes.time :as time]
             [clojure.string :as str]
-            [bluegenes.config :refer [read-default-ns]]))
+            [bluegenes.config :refer [read-default-ns]]
+            [bluegenes.components.bootstrap :refer [poppable]]
+            [bluegenes.components.icons :refer [icon]]))
 
 (def ^:const logo-path "/model/images/logo.png")
 
@@ -200,41 +202,49 @@
 
 (defn mine-entry
   "Output a single mine in the mine picker"
-  [mine-key details & {:keys [current?]}]
+  [mine-key details & {:keys [current? external?]}]
   [:li
    (when-let [desc (not-empty (:description details))]
      {:title desc})
-   [:a (if current?
-         {:class "current"}
-         {:href (route/href ::route/home {:mine mine-key})})
+   [:a (cond
+         current? {:class "current"}
+         external? {:target "_blank" :href (:url details)}
+         :else {:href (route/href ::route/home {:mine mine-key})})
     [mine-icon details]
     (str (:name details)
          (when (= mine-key (read-default-ns))
-           " (default)"))]])
+           " (default)"))
+    (when external?
+      [icon "external"])]])
 
 (defn mine-picker []
   (let [current-mine-name @(subscribe [:current-mine-name])
         current-mine @(subscribe [:current-mine])
         registry @(subscribe [:registry-wo-configured-mines])
-        configured-mines @(subscribe [:env/mines])]
+        registry-external @(subscribe [:registry-external])
+        configured-mines @(subscribe [:env/mines])
+        map-mines (fn [mines & {:keys [external?]}]
+                    (map (fn [[mine-key details]]
+                           ^{:key mine-key}
+                           [mine-entry mine-key details
+                            :current? (= mine-key current-mine-name)
+                            :external? external?])
+                         (sort-by (comp :name val) mines)))]
     [:li.minename.mine-settings.dropdown.primary-nav
      [:a.dropdown-toggle {:data-toggle "dropdown" :role "button"}
       [active-mine-logo current-mine]
       [:span.hidden-xs (:name current-mine)]
       [:svg.icon.icon-caret-down [:use {:xlinkHref "#icon-caret-down"}]]]
      (into [:ul.dropdown-menu.mine-picker]
-           (concat (map (fn [[mine-key details]]
-                          ^{:key mine-key}
-                          [mine-entry mine-key details
-                           :current? (= mine-key current-mine-name)])
-                        (sort-by (comp :name val) configured-mines))
+           (concat (map-mines configured-mines)
                    (when (seq registry)
                      [[:li.header [:h4 "Registry mines"]]])
-                   (map (fn [[mine-key details]]
-                          ^{:key mine-key}
-                          [mine-entry mine-key details
-                           :current? (= mine-key current-mine-name)])
-                        (sort-by (comp :name val) registry))))]))
+                   (map-mines registry)
+                   (when (seq registry-external)
+                     [[:li.header [:h4 "Incompatible mines"
+                                   [poppable {:data "These mines are incompatible due to either running an InterMine API version below 27 or being only available through unsecured HTTP when BlueGenes is accessed through HTTPS. Selecting any of them will open a new tab."
+                                              :children [icon "question"]}]]]])
+                   (map-mines registry-external :external? true)))]))
 
 (def queries-to-show 5)
 

--- a/src/cljs/bluegenes/events/boot.cljs
+++ b/src/cljs/bluegenes/events/boot.cljs
@@ -123,10 +123,11 @@
 
 (defn init-configured-mine
   "Parse configured mine data passed from BlueGenes config."
-  [{:keys [root name namespace]}]
+  [{:keys [root name namespace external]}]
   {:id (keyword namespace)
    :name name
-   :service {:root root}})
+   :service {:root root}
+   :external? external})
 
 (defn init-mine-defaults
   "Load default mine data, as passed from a coupled InterMine or defined in

--- a/src/cljs/bluegenes/pages/reportpage/components/sidebar.cljs
+++ b/src/cljs/bluegenes/pages/reportpage/components/sidebar.cljs
@@ -128,11 +128,17 @@
                                                     (not expanded?) (take entries-to-show))]
                              (into [:div
                                     [:span.organism organism]]
-                                   (for [gene genes]
-                                     [:a {:href (route/href ::route/report {:mine mine-kw
-                                                                            :type "Gene"
-                                                                            :id (:id gene)})}
-                                      (some gene [:symbol :primaryIdentifier :secondaryIdentifier])])))
+                                   (for [gene genes
+                                         :let [nom (some gene [:symbol :primaryIdentifier :secondaryIdentifier])]]
+                                     (if (:external? mine)
+                                       [:a {:target "_blank"
+                                            :href (str (:url mine) "/report.do?id=" (:id gene))}
+                                        nom
+                                        [icon-comp "external"]]
+                                       [:a {:href (route/href ::route/report {:mine mine-kw
+                                                                              :type "Gene"
+                                                                              :id (:id gene)})}
+                                        nom]))))
 
                            :else
                            [[:span "No results"]]))

--- a/src/cljs/bluegenes/subs.cljs
+++ b/src/cljs/bluegenes/subs.cljs
@@ -42,7 +42,8 @@
  :<- [:registry-external]
  :<- [:env/mines]
  (fn [[registry registry-external configured]]
-   (merge configured registry registry-external)))
+   ;; Merge to a depth of 1, causing differing keys within the mine map to be kept.
+   (merge-with merge registry registry-external configured)))
 
 ;; Removes configured mines from registry.
 ;; For when we want to display them separate!

--- a/src/cljs/bluegenes/subs.cljs
+++ b/src/cljs/bluegenes/subs.cljs
@@ -29,14 +29,20 @@
  (fn [db]
    (:registry db)))
 
+(reg-sub
+ :registry-external
+ (fn [db]
+   (:registry-external db)))
+
 ;; Combines registry and configured mines, merging mines with the same namespace.
 ;; For when we want to display them all together!
 (reg-sub
  :registry+configured-mines
  :<- [:registry]
+ :<- [:registry-external]
  :<- [:env/mines]
- (fn [[registry configured]]
-   (merge configured registry)))
+ (fn [[registry registry-external configured]]
+   (merge configured registry registry-external)))
 
 ;; Removes configured mines from registry.
 ;; For when we want to display them separate!

--- a/src/cljs/bluegenes/utils.cljs
+++ b/src/cljs/bluegenes/utils.cljs
@@ -119,6 +119,22 @@
    :id (-> reg-mine :namespace keyword)
    :logo (-> reg-mine :images :logo)})
 
+(defn get-mine-ns
+  "Return the mine namespace as a keyword.
+  Handles both mines from the registry and config."
+  [mine]
+  (if (contains? mine :service) ; Only config mines have :service
+    (:id mine)
+    (keyword (:namespace mine))))
+
+(defn get-mine-url
+  "Return the mine url.
+  Handles both mines from the registry and config."
+  [mine]
+  (if (contains? mine :service) ; Only config mines have :service
+    (get-in mine [:service :root])
+    (:url mine)))
+
 (defn read-xml-query
   "Read an InterMine PathQuery in XML into an EDN Clojure map.
   Will throw on invalid XML."


### PR DESCRIPTION
...instead of not showing them at all.
This affects the mine switcher in the navbar and on the home page. #724
