### PR TITLE
BG backend service root, custom deploy path and better errors

### DIFF
--- a/config/defaults/config.edn
+++ b/config/defaults/config.edn
@@ -4,6 +4,7 @@
  :logging-level "info"
  :google-analytics nil
  :bluegenes-tool-path "./tools"
+ :bluegenes-backend-service-root nil
  :bluegenes-default-service-root "https://www.flymine.org/flymine"
  :bluegenes-default-mine-name "FlyMine"
  :bluegenes-default-namespace "flymine"

--- a/config/defaults/config.edn
+++ b/config/defaults/config.edn
@@ -4,6 +4,7 @@
  :logging-level "info"
  :google-analytics nil
  :bluegenes-tool-path "./tools"
+ :bluegenes-deploy-path nil
  :bluegenes-backend-service-root nil
  :bluegenes-default-service-root "https://www.flymine.org/flymine"
  :bluegenes-default-mine-name "FlyMine"
@@ -19,3 +20,4 @@
                               ]
  :hide-registry-mines false
  }
+

--- a/docs/building.md
+++ b/docs/building.md
@@ -95,6 +95,8 @@ Cypress also has a really useful interface for debugging failing tests:
 
     DEBUG=cypress:* npx cypress open
 
+*Tip:* You can also run the Cypress tests with BlueGenes deployed to a custom deploy path by editing *cypress.json* `baseUrl` key to include the path (e.g. `"http://localhost:5000/foo/bar"`) and passing the same path as an envvar, `BLUEGENES_DEPLOY_PATH=/foo/bar lein biotestmine`
+
 # Production Builds
 
 ## Testing a minified instance before deploying:

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -8,6 +8,7 @@
 | LOGGING_LEVEL | Minimum level for logging | info |
 | GOOGLE_ANALYTICS | Google Analytics tracking ID | nil |
 | BLUEGENES_TOOL_PATH | Directory on server where BlueGenes tools are installed | ./tools |
+| BLUEGENES_DEPLOY_PATH | Custom URL path to host BlueGenes. Should **not** end with `/`. If you wish to host at root, set to `nil`. | nil |
 | BLUEGENES_BACKEND_SERVICE_ROOT | Override BLUEGENES_DEFAULT_SERVICE_ROOT for backend API requests (usually an internal address) | nil |
 | BLUEGENES_DEFAULT_SERVICE_ROOT | Default InterMine service to run API requests against | https://www.flymine.org/flymine |
 | BLUEGENES_DEFAULT_MINE_NAME | Mine name to display for default mine | FlyMine |

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -8,6 +8,7 @@
 | LOGGING_LEVEL | Minimum level for logging | info |
 | GOOGLE_ANALYTICS | Google Analytics tracking ID | nil |
 | BLUEGENES_TOOL_PATH | Directory on server where BlueGenes tools are installed | ./tools |
+| BLUEGENES_BACKEND_SERVICE_ROOT | Override BLUEGENES_DEFAULT_SERVICE_ROOT for backend API requests (usually an internal address) | nil |
 | BLUEGENES_DEFAULT_SERVICE_ROOT | Default InterMine service to run API requests against | https://www.flymine.org/flymine |
 | BLUEGENES_DEFAULT_MINE_NAME | Mine name to display for default mine | FlyMine |
 | BLUEGENES_DEFAULT_NAMESPACE | Namespace of the default mine | flymine |

--- a/project.clj
+++ b/project.clj
@@ -4,6 +4,21 @@
       :out
       clojure.string/trim))
 
+(defn ?slurp
+  "Slurp that returns nil if file doesn't exist."
+  [f]
+  (try (slurp f) (catch java.io.FileNotFoundException _)))
+
+(def deploy-path
+  "Reads the :bluegenes-deploy-path key from envvar, config/dev/config.edn or
+  config/defaults/config.edn in order of decending precedence. This is only
+  used for development builds, which is why it doesn't cover all configuration
+  methods of yogthos/config."
+  (or (System/getenv "BLUEGENES_DEPLOY_PATH")
+      (some-> (or (?slurp "config/dev/config.edn")
+                  (?slurp "config/defaults/config.edn"))
+              (clojure.edn/read-string) (:bluegenes-deploy-path))))
+
 (defproject org.intermine/bluegenes "1.2.1"
   :licence "LGPL-2.1-only"
   :description "Bluegenes is a Clojure-powered user interface for InterMine, the biological data warehouse"
@@ -154,7 +169,7 @@
                                         :optimizations :none
                                         :output-to "resources/public/js/compiled/app.js"
                                         :output-dir "resources/public/js/compiled"
-                                        :asset-path "/js/compiled"
+                                        :asset-path ~(str deploy-path "/js/compiled")
                                         :source-map-timestamp true
                                         :pretty-print true
                                         ;:parallel-build true

--- a/project.clj
+++ b/project.clj
@@ -86,7 +86,7 @@
                  ; Intermine Assets
                  [org.intermine/imcljs "1.4.5"]
                  [org.intermine/im-tables "0.14.0"]
-                 [org.intermine/bluegenes-tool-store "0.2.2"]]
+                 [org.intermine/bluegenes-tool-store "0.2.3"]]
 
   :deploy-repositories {"clojars" {:sign-releases false}}
   :codox {:language :clojurescript}

--- a/project.clj
+++ b/project.clj
@@ -9,6 +9,11 @@
   [f]
   (try (slurp f) (catch java.io.FileNotFoundException _)))
 
+(defn ?read-string
+  "clojure.edn/read-string that returns nil instead of throwing."
+  [s]
+  (try (clojure.edn/read-string s) (catch Throwable _)))
+
 (def deploy-path
   "Reads the :bluegenes-deploy-path key from envvar, config/dev/config.edn or
   config/defaults/config.edn in order of decending precedence. This is only
@@ -17,7 +22,10 @@
   (or (System/getenv "BLUEGENES_DEPLOY_PATH")
       (some-> (or (?slurp "config/dev/config.edn")
                   (?slurp "config/defaults/config.edn"))
-              (clojure.edn/read-string) (:bluegenes-deploy-path))))
+              ;; We don't want to throw here if something is wrong with the
+              ;; configs as it will get validated anyways when BlueGenes starts
+              ;; and with much better errors.
+              (?read-string) (:bluegenes-deploy-path))))
 
 (defproject org.intermine/bluegenes "1.2.1"
   :licence "LGPL-2.1-only"

--- a/src/clj/bluegenes/config.clj
+++ b/src/clj/bluegenes/config.clj
@@ -3,14 +3,16 @@
             [clojure.string :as str]))
 
 (s/def ::non-empty-string (s/and string? (complement str/blank?)))
+(s/def ::optional-string (s/or :nil nil? :string string?))
 (s/def ::integer-string (s/and string? #(re-matches #"^[0-9]+$" %)))
 
 (s/def ::server-port (s/or :int int? :string ::integer-string))
 (s/def ::logging-level #{"trace" "debug" "info" "warn" "error" "fatal" "report"})
-(s/def ::google-analytics (s/or :nil nil? :string string?))
+(s/def ::google-analytics ::optional-string)
 (s/def ::hide-registry-mines boolean?)
 
 (s/def ::bluegenes-tool-path ::non-empty-string)
+(s/def ::bluegenes-backend-service-root ::optional-string)
 (s/def ::bluegenes-default-service-root ::non-empty-string)
 (s/def ::bluegenes-default-mine-name ::non-empty-string)
 (s/def ::bluegenes-default-namespace ::non-empty-string)
@@ -22,7 +24,7 @@
 (s/def ::bluegenes-additional-mines (s/coll-of ::additional-mine :kind vector?))
 
 (s/def ::bluegenes-config (s/keys :req-un [::bluegenes-tool-path
-                                           ::bluegenes-default-service-root ::bluegenes-default-mine-name ::bluegenes-default-namespace]
+                                           ::bluegenes-backend-service-root ::bluegenes-default-service-root ::bluegenes-default-mine-name ::bluegenes-default-namespace]
                                   :opt-un [::bluegenes-additional-mines
                                            ::server-port ::logging-level ::google-analytics ::hide-registry-mines]))
 

--- a/src/clj/bluegenes/config.clj
+++ b/src/clj/bluegenes/config.clj
@@ -44,8 +44,8 @@
 (defn validate-config [env]
   (when-not (s/valid? ::bluegenes-config env)
     (throw (AssertionError.
-             (str "Invalid config: "
-                  \newline
-                  (-> (s/explain-data ::bluegenes-config env) ::s/problems spec-problems-str)
-                  \newline \newline
-                  "Please check your config.edn or envvars.")))))
+            (str "Invalid config: "
+                 \newline
+                 (-> (s/explain-data ::bluegenes-config env) ::s/problems spec-problems-str)
+                 \newline \newline
+                 "Please check your config.edn or envvars.")))))

--- a/src/clj/bluegenes/handler.clj
+++ b/src/clj/bluegenes/handler.clj
@@ -1,7 +1,5 @@
 (ns bluegenes.handler
   (:require [bluegenes.routes :refer [routes]]
-            [bluegenes-tool-store.core :as tool]
-            [compojure.core :as compojure]
             [ring.middleware.session :refer [wrap-session]]
             [ring.middleware.reload :refer [wrap-reload]]
             [compojure.middleware :refer [wrap-canonical-redirect]]
@@ -20,10 +18,7 @@
         uri))
     uri))
 
-(def combined-routes
-  (compojure/routes tool/routes routes))
-
-(def handler (-> #'combined-routes
+(def handler (-> #'routes
                  ;; Watch changes to the .clj and hot reload them
                  (cond-> (:development env) (wrap-reload {:dirs ["src/clj"]}))
                  ;; Add session functionality

--- a/src/clj/bluegenes/index.clj
+++ b/src/clj/bluegenes/index.clj
@@ -72,6 +72,13 @@
                (pr-str (.getMessage e)))
         nil))))
 
+(defn use-deployment-path
+  "Takes a URL string to a resource and prefixes the deployment path if defined."
+  [url]
+  (if-let [path (:bluegenes-deploy-path env)]
+    (str path url)
+    url))
+
 (defn head
   ([]
    (head nil {}))
@@ -87,8 +94,8 @@
         [:link {:href rdf-url :rel "alternate" :type "application/rdf+xml" :title "RDF"}]))
     (include-css "https://cdnjs.cloudflare.com/ajax/libs/gridlex/2.2.0/gridlex.min.css")
     (include-css "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css")
-    (include-css bluegenes-css)
-    (include-css im-tables-css)
+    (include-css (use-deployment-path bluegenes-css))
+    (include-css (use-deployment-path im-tables-css))
     (include-css "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css")
     (include-css "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/github.min.css")
     ; Meta data:
@@ -99,7 +106,7 @@
      (str "var serverVars="
           (let [server-vars (merge (select-keys env [:google-analytics
                                                      :bluegenes-default-service-root :bluegenes-default-mine-name :bluegenes-default-namespace
-                                                     :bluegenes-additional-mines :hide-registry-mines])
+                                                     :bluegenes-additional-mines :hide-registry-mines :bluegenes-deploy-path])
                                    {:version bundle-hash})]
             (str \" (escape-quotes (pr-str server-vars)) \"))
           ";")
@@ -110,7 +117,7 @@
           ";")]
   ; Javascript:
     ;; This favicon is dynamically served; see routes.clj.
-    [:link {:href "/favicon.ico" :type "image/x-icon" :rel "shortcut icon"}]
+    [:link {:href (use-deployment-path "/favicon.ico") :type "image/x-icon" :rel "shortcut icon"}]
     [:script {:src "https://cdn.intermine.org/js/intermine/imjs/latest/im.min.js"}]
     [:script {:crossorigin "anonymous"
               :integrity "sha256-cCueBR6CsyA4/9szpPfrX3s49M9vUU5BgtiJj06wt/s="
@@ -159,7 +166,7 @@
      (css-compiler)
      (loader)
      [:div#app]
-     [:script {:src bundle-path}]
+     [:script {:src (use-deployment-path bundle-path)}]
      ;; Call the constructor of the bluegenes client and pass in the user's
      ;; optional identity as an object.
      [:script "bluegenes.core.init();"]])))

--- a/src/clj/bluegenes/routes.clj
+++ b/src/clj/bluegenes/routes.clj
@@ -38,22 +38,23 @@
       (found (str (:bluegenes-deploy-path env) "/favicon-fallback.ico")))))
 
 (defn not-found-page [{:keys [request-method uri] :as _req}]
-  (html5
-   [:head
-    [:title "Page Not Found"]
-    [:style "h1{ font-size:80px; font-weight:800; text-align:center; font-family: 'Roboto', sans-serif; } h2 { font-size:25px; text-align:center; font-family: 'Roboto', sans-serif; margin-top:-40px; } p{ text-align:center; font-family: 'Roboto', sans-serif; font-size:12px; } .container { width:300px; margin: 0 auto; margin-top:15%; }"]]
-   [:body
-    [:div.container
-     [:h1 "404"]
-     [:h2 "Page Not Found"]
-     [:p "This " [:strong (-> request-method name str/upper-case)] " request to " [:strong uri] " is not handled by the BlueGenes server, which is deployed to " [:strong (:bluegenes-deploy-path env "/")] ". "
-      [:a {:href (:bluegenes-deploy-path env "/")} "Click here"] " to open BlueGenes."]]]))
+  (let [bg-path (or (:bluegenes-deploy-path env) "/")]
+    (html5
+     [:head
+      [:title "Page Not Found"]
+      [:style "h1{ font-size:80px; font-weight:800; text-align:center; font-family: 'Roboto', sans-serif; } h2 { font-size:25px; text-align:center; font-family: 'Roboto', sans-serif; margin-top:-40px; } p{ text-align:center; font-family: 'Roboto', sans-serif; font-size:12px; } .container { width:300px; margin: 0 auto; margin-top:15%; }"]]
+     [:body
+      [:div.container
+       [:h1 "404"]
+       [:h2 "Page Not Found"]
+       [:p "This " [:strong (-> request-method name str/upper-case)] " request to " [:strong uri] " is not handled by the BlueGenes server, which is deployed to " [:strong bg-path] ". "
+        [:a {:href bg-path} "Click here"] " to open BlueGenes."]]])))
 
 ; Define the top level URL routes for the server
 (def routes
   (compojure/let-routes [mines (env->mines env)
                          favicon* (delay (get-favicon))]
-    (context (:bluegenes-deploy-path env "/") []
+    (context (:bluegenes-deploy-path env) []
       ;;serve compiled files, i.e. js, css, from the resources folder
       (resources "/")
 

--- a/src/clj/bluegenes/routes.clj
+++ b/src/clj/bluegenes/routes.clj
@@ -9,7 +9,7 @@
             [bluegenes.ws.lookup :as lookup]
             [bluegenes.index :refer [index]]
             [config.core :refer [env]]
-            [bluegenes.utils :refer [env->mines]]
+            [bluegenes.utils :refer [env->mines get-service-root]]
             [clj-http.client :as client]))
 
 (defn with-init
@@ -27,7 +27,7 @@
 (defn get-favicon
   "Get a favicon for when one isn't configured."
   []
-  (let [mine-favicon (str (:bluegenes-default-service-root env) "/model/images/favicon.ico")]
+  (let [mine-favicon (str (get-service-root env) "/model/images/favicon.ico")]
     (if (-> (client/get mine-favicon)
             (get-in [:headers "Content-Type"])
             (= "image/x-icon"))

--- a/src/clj/bluegenes/utils.clj
+++ b/src/clj/bluegenes/utils.clj
@@ -47,11 +47,15 @@
   [file-path fingerprint]
   (str/replace file-path #"\.css$" (str "-" fingerprint ".css")))
 
+(defn get-service-root [env]
+  (or (not-empty (:bluegenes-backend-service-root env))
+      (:bluegenes-default-service-root env)))
+
 (defn env->mines
   "Parses env to return a vector of configured mines.
   Guarantees first mine to always be default."
   [env]
-  (concat [{:root (:bluegenes-default-service-root env)
+  (concat [{:root (get-service-root env)
             :name (:bluegenes-default-mine-name env)
             :namespace (:bluegenes-default-namespace env)}]
           (:bluegenes-additional-mines env)))

--- a/src/clj/bluegenes/ws/auth.clj
+++ b/src/clj/bluegenes/ws/auth.clj
@@ -5,7 +5,8 @@
             [ring.util.http-response :as response]
             [taoensso.timbre :as timbre]
             [ring.middleware.params :refer [wrap-params]]
-            [ring.middleware.keyword-params :refer [wrap-keyword-params]]))
+            [ring.middleware.keyword-params :refer [wrap-keyword-params]]
+            [config.core :refer [env]]))
 
 ;; You may notice that we keep session data on the backend, although this data
 ;; is currently not used (except for OAuth 2.0, which only depends on the
@@ -33,19 +34,33 @@
 ;; each API client has been doing this. At some point we might raise this
 ;; question again...
 
+(defn use-backend-service
+  "Substitute service root for the one the backend is configured to use, if it
+  is so configured and matches the equivalent service root for the frontend.
+  The latter check is required as we could be connecting to an external mine."
+  [service]
+  (let [{default :bluegenes-default-service-root
+         backend :bluegenes-backend-service-root} env
+        backend (not-empty backend)]
+    (cond
+      (nil? backend) service
+      (= (:root service) default) (assoc service :root backend)
+      :else service)))
+
 (defn logout
   "Log the user out by clearing the session. Also sends a request to the InterMine
   instance to invalidate the token."
   [{{:keys [service]} :params :as _req}]
-  (try
-    ;; Might throw if we're missing token (401) or if the InterMine instance
-    ;; is older and doesn't have the service implemented (invalid response).
-    (im-auth/logout service)
-    (-> (response/ok {:success true})
-        (assoc :session nil))
-    (catch Exception _
+  (let [service (use-backend-service service)]
+    (try
+      ;; Might throw if we're missing token (401) or if the InterMine instance
+      ;; is older and doesn't have the service implemented (invalid response).
+      (im-auth/logout service)
       (-> (response/ok {:success true})
-          (assoc :session nil)))))
+          (assoc :session nil))
+      (catch Exception _
+        (-> (response/ok {:success true})
+            (assoc :session nil))))))
 
 (defn login
   "Login using the new login service, with fallback to basic auth."
@@ -65,47 +80,50 @@
   IM server (via web services) by fetching a token. If successful, return
   the token and store it in the session."
   [{{:keys [username password service]} :params :as _req}]
-  (try
-    (let [[user+token renamedLists] (login service username password)]
-      (-> (response/ok {:identity user+token
-                        :renamedLists renamedLists})
-          (assoc :session ^:recreate {:identity user+token})))
-    (catch Exception e
-      (let [{:keys [status] :as res} (ex-data e)]
-        (if status
-          res
-          (response/internal-server-error {:error (ex-message e)}))))))
+  (let [service (use-backend-service service)]
+    (try
+      (let [[user+token renamedLists] (login service username password)]
+        (-> (response/ok {:identity user+token
+                          :renamedLists renamedLists})
+            (assoc :session ^:recreate {:identity user+token})))
+      (catch Exception e
+        (let [{:keys [status] :as res} (ex-data e)]
+          (if status
+            res
+            (response/internal-server-error {:error (ex-message e)})))))))
 
 (defn register
   "Ring handler for registering a new user with the IM server. If successful,
   perform a regular login to get a proper token and store it in the session."
   [{{:keys [username password service]} :params :as _req}]
-  (try
-    ;; Registration only returns a temporaryToken valid for 24 hours.
-    (im-auth/register service username password)
-    ;; We call the login service directly after so we can get a proper token.
-    (let [[user+token renamedLists] (login service username password)]
-      ;; We're passing renamedLists although there shouldn't be any due to
-      ;; being a new account.
-      (-> (response/ok {:identity user+token
-                        :renamedLists renamedLists})
-          (assoc :session ^:recreate {:identity user+token})))
-    (catch Exception e
-      (let [{:keys [status] :as res} (ex-data e)]
-        (if status
-          res
-          (response/internal-server-error {:error (ex-message e)}))))))
+  (let [service (use-backend-service service)]
+    (try
+      ;; Registration only returns a temporaryToken valid for 24 hours.
+      (im-auth/register service username password)
+      ;; We call the login service directly after so we can get a proper token.
+      (let [[user+token renamedLists] (login service username password)]
+        ;; We're passing renamedLists although there shouldn't be any due to
+        ;; being a new account.
+        (-> (response/ok {:identity user+token
+                          :renamedLists renamedLists})
+            (assoc :session ^:recreate {:identity user+token})))
+      (catch Exception e
+        (let [{:keys [status] :as res} (ex-data e)]
+          (if status
+            res
+            (response/internal-server-error {:error (ex-message e)})))))))
 
 (defn oauth2authenticator
   [{{:keys [service mine-id provider redirect_uri]} :params :as _req}]
-  (try
-    (-> (response/ok (im-auth/oauth2authenticator service provider))
-        (assoc :session {:service service
-                         :mine-id mine-id
-                         :redirect_uri redirect_uri}))
-    (catch Exception e
-      ;; Forward the error response to client so it can handle it.
-      (ex-data e))))
+  (let [service (use-backend-service service)]
+    (try
+      (-> (response/ok (im-auth/oauth2authenticator service provider))
+          (assoc :session {:service service
+                           :mine-id mine-id
+                           :redirect_uri redirect_uri}))
+      (catch Exception e
+        ;; Forward the error response to client so it can handle it.
+        (ex-data e)))))
 
 (defn oauth2callback
   [{{:keys [provider state code]} :params

--- a/src/clj/bluegenes/ws/auth.clj
+++ b/src/clj/bluegenes/ws/auth.clj
@@ -33,6 +33,8 @@
 ;; "client manages token" approach chosen by default for historical reasons, as
 ;; each API client has been doing this. At some point we might raise this
 ;; question again...
+;; ^ not possible right now; JSESSIONID only works for JSP webapp, not WS requests
+;; => Keep it as it is!
 
 (defn use-backend-service
   "Substitute service root for the one the backend is configured to use, if it
@@ -134,7 +136,7 @@
           user+token (assoc user
                             :token token
                             :login-method :oauth2)]
-      (-> (response/found (str "/" mine-id))
+      (-> (response/found (str (:bluegenes-deploy-path env) "/" mine-id))
           (assoc :session ^:recreate {:identity user+token
                                       :init {:identity user+token
                                              :renamedLists renamedLists}})))
@@ -143,7 +145,7 @@
       (let [{:keys [body]} (ex-data e)
             error (or (:error (cheshire/parse-string body true))
                       (ex-message e))]
-        (-> (response/found (str "/" mine-id))
+        (-> (response/found (str (:bluegenes-deploy-path env) "/" mine-id))
             (assoc :session {:init {:events [[:messages/add
                                               {:style "warning"
                                                :markup (str "Failed to login using OAuth 2.0"

--- a/src/clj/bluegenes/ws/lookup.clj
+++ b/src/clj/bluegenes/ws/lookup.clj
@@ -5,7 +5,8 @@
             [clojure.string :as str]
             [cheshire.core :as cheshire]
             [clj-http.client :refer [with-middleware]]
-            [bluegenes.utils :as utils]))
+            [bluegenes.utils :as utils]
+            [config.core :refer [env]]))
 
 (def extension->content-type
   {"rdf" "application/rdf+xml;charset=UTF-8"})
@@ -13,7 +14,7 @@
 (defn handle-failed-lookup [lookup-string {:keys [namespace]} error-string]
   (let [msg [:span "Failed to parse permanent URL for " [:em lookup-string] " "
              [:code error-string]]]
-    (-> (response/found (str "/" namespace))
+    (-> (response/found (str (:bluegenes-deploy-path env) "/" namespace))
         (assoc :session {:init {:events [[:messages/add
                                           {:style "warning"
                                            :timeout 0
@@ -30,7 +31,8 @@
                     :value identifier}]}
         res (im-fetch/rows service q)]
     (if-let [object-id (get-in res [:results 0 0])]
-      (response/found (str "/" namespace
+      (response/found (str (:bluegenes-deploy-path env)
+                           "/" namespace
                            "/" "report"
                            "/" object-type
                            "/" object-id))

--- a/src/cljs/bluegenes/components/navbar/nav.cljs
+++ b/src/cljs/bluegenes/components/navbar/nav.cljs
@@ -9,7 +9,7 @@
             [bluegenes.components.icons :refer [icon-comp]]
             [bluegenes.time :as time]
             [clojure.string :as str]
-            [bluegenes.config :refer [read-default-ns]]
+            [bluegenes.config :refer [read-default-ns server-vars]]
             [bluegenes.components.bootstrap :refer [poppable]]
             [bluegenes.components.icons :refer [icon]]
             [bluegenes.utils :refer [get-mine-url]]))
@@ -162,14 +162,14 @@
          {:type "button"
           :on-click #(dispatch [:bluegenes.events.auth/oauth2 "GOOGLE"])}
          [:img.google-signin
-          {:src "/images/google-signin.png"
+          {:src (str (:bluegenes-deploy-path @server-vars) "/images/google-signin.png")
            :alt "[Sign in with Google]"}]])
       (when (contains? oauth2-providers "ELIXIR")
         [:button.btn
          {:type "button"
           :on-click #(dispatch [:bluegenes.events.auth/oauth2 "ELIXIR"])}
          [:img.elixir-login
-          {:src "/images/elixir-login.png"
+          {:src (str (:bluegenes-deploy-path @server-vars) "/images/elixir-login.png")
            :alt "[ELIXIR Login]"}]])]]))
 
 (defn anonymous []

--- a/src/cljs/bluegenes/components/tools/effects.cljs
+++ b/src/cljs/bluegenes/components/tools/effects.cljs
@@ -4,7 +4,8 @@
             [bluegenes.components.tools.events :as events]
             [bluegenes.route :as route]
             [bluegenes.utils :refer [suitable-entities]]
-            [clojure.string :as str]))
+            [clojure.string :as str]
+            [bluegenes.config :refer [server-vars]]))
 
 (defmulti navigate
   "Can be used from JS like this:
@@ -80,7 +81,8 @@
         (when tool-path
           (oset! script-tag "id" script-id)
           ;;fetch script from bluegenes-tool-store backend
-          (oset! script-tag "src" (str "/tools/" (get-in tool [:names :npm])
+          (oset! script-tag "src" (str (:bluegenes-deploy-path @server-vars)
+                                       "/tools/" (get-in tool [:names :npm])
                                        "/" tool-path
                                        "?v=" (get-in tool [:package :version])))
           ;;run-script will automatically be triggered when the script loads
@@ -103,7 +105,8 @@
         (when style-path
           ;;fetch stylesheet and set some properties
           (oset! style-tag "id" style-id)
-          (oset! style-tag "href" (str "/tools/" (get-in tool [:names :npm])
+          (oset! style-tag "href" (str (:bluegenes-deploy-path @server-vars)
+                                       "/tools/" (get-in tool [:names :npm])
                                        "/" style-path
                                        "?v=" (get-in tool [:package :version])))
           (oset! style-tag "type" "text/css")

--- a/src/cljs/bluegenes/error.cljs
+++ b/src/cljs/bluegenes/error.cljs
@@ -5,7 +5,8 @@
             [goog.json :as json]
             [goog.string :as gstring]
             [cljs-time.core :as time]
-            [cljs-time.format :refer [unparse formatters]]))
+            [cljs-time.format :refer [unparse formatters]]
+            [bluegenes.config :refer [server-vars]]))
 
 ;; This email is used if no maintainerEmail is available, or when we wish to
 ;; CC support (ie. when the failure is caused by a software problem).
@@ -80,7 +81,8 @@ ERROR: " error)))))
       :render (fn [this]
                 (let [clear-error! (fn []
                                      ;; Change URL to root without triggering router.
-                                     (.pushState js/window.history nil "" "/")
+                                     (.pushState js/window.history nil ""
+                                                 (str (:bluegenes-deploy-path @server-vars) "/"))
                                      ;; Boot and clear error.
                                      (dispatch-sync [:boot])
                                      (reset! !error nil)

--- a/src/cljs/bluegenes/events/auth.cljs
+++ b/src/cljs/bluegenes/events/auth.cljs
@@ -3,7 +3,8 @@
             [bluegenes.effects :as fx]
             [bluegenes.route :as route]
             [imcljs.auth :as im-auth]
-            [bluegenes.interceptors :refer [origin]]))
+            [bluegenes.interceptors :refer [origin]]
+            [bluegenes.config :refer [server-vars]]))
 
 (defn slim-service
   "Constrains a service map to only the keys needed by the backend API."
@@ -210,7 +211,10 @@
  (fn [{db :db origin :origin} [_ provider]]
    (let [current-mine (:current-mine db)
          service (get-in db [:mines current-mine :service])
-         redirect_uri (str origin "/api/auth/oauth2callback?provider=" provider)]
+         redirect_uri (str origin
+                           (str (:bluegenes-deploy-path @server-vars)
+                                "/api/auth/oauth2callback?provider=")
+                           provider)]
      {:db (update-in db [:mines current-mine :auth] assoc
                      :error? false)
       ::fx/http {:uri "/api/auth/oauth2authenticator"

--- a/src/cljs/bluegenes/events/boot.cljs
+++ b/src/cljs/bluegenes/events/boot.cljs
@@ -153,11 +153,7 @@
    (let [default-ns (read-default-ns)
          ;; We have to set the db current-mine using `window.location` as the
          ;; router won't have dispatched `:set-current-mine` before later on.
-         current-mine (-> (.. js/window -location -pathname)
-                          (str/split #"/")
-                          (second)
-                          (keyword)
-                          (or default-ns))
+         current-mine (or (keyword (utils/mine-from-pathname)) default-ns)
          ;; These could be passed from the Bluegenes backend and result in
          ;; events being dispatched.
          renamedLists (some-> @init-vars :renamedLists not-empty)

--- a/src/cljs/bluegenes/pages/home/views.cljs
+++ b/src/cljs/bluegenes/pages/home/views.cljs
@@ -12,7 +12,8 @@
             [cljs-time.format :as time-format]
             [cljs-time.coerce :as time-coerce]
             [oops.core :refer [oget]]
-            [bluegenes.components.bootstrap :refer [poppable]]))
+            [bluegenes.components.bootstrap :refer [poppable]]
+            [bluegenes.config :refer [server-vars]]))
 
 (defn mine-intro []
   (let [mine-name @(subscribe [:current-mine-human-name])
@@ -278,7 +279,7 @@
 
 (def credits-intermine
   [{:text "[InterMine](http://intermine.org/) has been developed principally through support of the [Wellcome Trust](https://wellcome.ac.uk/). Complementary projects have been funded by the [NIH/NHGRI](https://www.nih.gov/) and the [BBSRC](https://bbsrc.ukri.org/)."
-    :image "/images/intermine-logo.png"
+    :image (str (:bluegenes-deploy-path @server-vars) "/images/intermine-logo.png")
     :url "http://intermine.org/"}])
 
 (defn credits-fallback []

--- a/src/cljs/bluegenes/pages/tools/events.cljs
+++ b/src/cljs/bluegenes/pages/tools/events.cljs
@@ -80,7 +80,9 @@
                         ;; We don't use the current-mine, as the privilege
                         ;; check only runs on the configured default root.
                         :service (select-keys (get-in db [:mines (read-default-ns) :service])
-                                              [:root :token]))})))
+                                              [:root :token])
+                        ;; Used to display more informative error messages.
+                        :mine-name (get-in db [:mines (read-default-ns) :name]))})))
 
 (reg-event-db
  ::success-tool
@@ -101,7 +103,8 @@
  ::error-tool
  (fn [{db :db} [_ res]]
    (let [msg [:messages/add
-              {:markup [:span (get-in res [:body :error])]
+              {:markup [:span (or (get-in res [:body :error])
+                                  "Error occurred in Tool server. Please try again later.")]
                :style "warning"
                :timeout 0}]]
      {:dispatch-n [msg [::tools/fetch-tools]]

--- a/src/cljs/bluegenes/pages/tools/view.cljs
+++ b/src/cljs/bluegenes/pages/tools/view.cljs
@@ -154,24 +154,25 @@
   []
   (let [installed-tools (subscribe [::tools-subs/installed-tools])
         remaining-tools (subscribe [::tools-subs/remaining-tools])]
-    [:div.tool-store.container
-     [:h1 "Tool Store"]
-     [:div
-      (when (seq @installed-tools)
-        [:div.info
-         [:h4 "Installed tools"]
-         [:button.btn.btn-primary.btn-raised
-          {:on-click (action #(dispatch [::events/update-all-tools]))}
-          "Update installed tools"]])
-      [installed-tool-list installed-tools]
-      (when (seq @remaining-tools)
-        [:div.info
-         [:h4 "Available tools"]
-         [:button.btn.btn-primary.btn-raised
-          {:on-click (action #(dispatch [::events/install-all-tools]))}
-          "Install all tools"]])
-      [available-tool-list remaining-tools]
-      (when (seq all-viz)
-        [:div.info
-         [:h4 "Native visualizations"]])
-      [native-viz-list all-viz]]]))
+    (fn []
+      [:div.tool-store.container
+       [:h1 "Tool Store"]
+       [:div
+        (when (seq @installed-tools)
+          [:div.info
+           [:h4 "Installed tools"]
+           [:button.btn.btn-primary.btn-raised
+            {:on-click (action #(dispatch [::events/update-all-tools]))}
+            "Update installed tools"]])
+        [installed-tool-list installed-tools]
+        (when (seq @remaining-tools)
+          [:div.info
+           [:h4 "Available tools"]
+           [:button.btn.btn-primary.btn-raised
+            {:on-click (action #(dispatch [::events/install-all-tools]))}
+            "Install all tools"]])
+        [available-tool-list remaining-tools]
+        (when (seq all-viz)
+          [:div.info
+           [:h4 "Native visualizations"]])
+        [native-viz-list all-viz]]])))

--- a/src/cljs/bluegenes/pages/tools/view.cljs
+++ b/src/cljs/bluegenes/pages/tools/view.cljs
@@ -4,7 +4,8 @@
             [bluegenes.pages.tools.events :as events]
             [bluegenes.version :as version]
             [bluegenes.components.viz.views :refer [all-viz]]
-            [bluegenes.utils :refer [md-paragraph]]))
+            [bluegenes.utils :refer [md-paragraph]]
+            [bluegenes.config :refer [server-vars]]))
 
 ;; You may notice that this page is only linked from the admin's profile
 ;; dropdown, but there's no guard to stop logged in or anonymous users from
@@ -94,7 +95,9 @@
       [:div.tool
        [:h2 (get-in tool [:names :human])]
        (if (:hasimage tool)
-         [:div.tool-preview [:img {:src (:hasimage tool) :height "220px"}]]
+         [:div.tool-preview
+          [:img {:src (str (:bluegenes-deploy-path @server-vars) (:hasimage tool))
+                 :height "220px"}]]
          [:div.tool-no-preview "No tool preview available"])
        [:div.details
         [tool-description (get-in tool [:package :description])]

--- a/src/cljs/bluegenes/utils.cljs
+++ b/src/cljs/bluegenes/utils.cljs
@@ -7,7 +7,8 @@
             [bluegenes.components.icons :refer [icon]]
             [markdown-to-hiccup.core :as md]
             [goog.string :as gstring]
-            [oops.core :refer [ocall]]))
+            [oops.core :refer [ocall]]
+            [bluegenes.config :refer [server-vars]]))
 
 (defn hiccup-anchors-newtab
   "Add target=_blank to all anchor elements, so all links open in new tabs."
@@ -326,3 +327,15 @@
   (ocall js/URL "createObjectURL"
          (js/Blob. (clj->js [data])
                    {:type (str "text/" filetype)})))
+
+(defn mine-from-pathname
+  "Return mine name using pathname, or nil if not present. Factors in deploy path."
+  []
+  (let [pathname (.. js/window -location -pathname)
+        deploy-path (:bluegenes-deploy-path @server-vars)]
+    (-> pathname
+        (subs (min (count (str deploy-path "/"))
+                   (count pathname)))
+        (string/split #"/")
+        (first)
+        (not-empty))))


### PR DESCRIPTION
Introduce two new optional config vars:
- `:bluegenes-backend-service-root` for overriding the service root that the backend uses (usually for development purposes or increased performance, by using internal address)
- `:bluegenes-deploy-path` for BG deployments on non-root paths Fixes https://github.com/intermine/bluegenes/issues/744

In addition:
- Better error messages when something goes wrong when using Bluegenes tool store
- Much less verbose and more readable errors when BG is started with an invalid config/envvars
- 404 catch-all page (Mostly be prevalent when using a custom deploy-path and trying to access a path outside it. Otherwise, it's also useful for non-GET requests to paths not expecting it)

