### PR TITLE
Improve customisability of Bluegenes

### DIFF
--- a/src/cljs/bluegenes/components/footer/views.cljs
+++ b/src/cljs/bluegenes/components/footer/views.cljs
@@ -7,10 +7,6 @@
             [bluegenes.components.icons :refer [icon]]
             [bluegenes.route :as route]))
 
-(def defaults
-  {:email "info@intermine.org"
-   :twitter "intermineorg"})
-
 (defn link [href label]
   [:a {:href href :target "_blank"} label])
 
@@ -18,12 +14,7 @@
   (->> vstring version-string->vec (str/join ".")))
 
 (defn main []
-  (let [mine-name         @(subscribe [:current-mine-human-name])
-        mine-twitter      @(subscribe [:registry/twitter])
-        mine-email        @(subscribe [:registry/email])
-        mine-citation     @(subscribe [:current-mine/citation])
-        mine-news         @(subscribe [:current-mine/news])
-        short-version     (nth (re-matches #"v?([0-9\.]+)(?:-.*)?" version/release) 1 "dev")
+  (let [short-version     (nth (re-matches #"v?([0-9\.]+)(?:-.*)?" version/release) 1 "dev")
         ;; Note that the following versions can be nil when switching mines.
         intermine-version (some-> @(subscribe [:version]) pretty-version)
         api-version       @(subscribe [:api-version])
@@ -51,27 +42,28 @@
         [:span.thin " | "]
         [link "https://bbsrc.ukri.org/" "BBSRC"]]]]
      [:div.section
-      [link "https://github.com/intermine/"
-       [poppable {:data [:span "Check out our open-source software"]
-                  :children [icon "github" 2]}]]
-      [link (str "mailto:" (or mine-email (:email defaults)))
-       [poppable {:data [:span (if (and mine-email (not= mine-email (:email defaults)))
-                                 (str "Send " mine-name " an email")
-                                 "Send us an email")]
-                  :children [icon "mail" 2]}]]
-      [link mine-news
-       [poppable {:data [:span "Read our blog"]
-                  :children [icon "blog" 2]}]]
-      [link (str "https://twitter.com/" (or mine-twitter (:twitter defaults)))
-       [poppable {:data [:span (if (and mine-twitter (not= mine-twitter (:twitter defaults)))
-                                 (str "Follow " mine-name " on Twitter")
-                                 "Follow us on Twitter")]
-                  :children [icon "twitter" 2]}]]
-      [link "http://chat.intermine.org/"
-       [poppable {:data [:span "Chat with us on Discord"]
-                  :children [icon "discord" 2]}]]]
+      (when-let [github-url @(subscribe [:current-mine/url :github])]
+        [link github-url
+         [poppable {:data [:span "Check out our open-source software"]
+                    :children [icon "github" 2]}]])
+      (when-let [email @(subscribe [:current-mine/support-email])]
+        [link (str "mailto:" email)
+         [poppable {:data [:span "Send us an email"]
+                    :children [icon "mail" 2]}]])
+      (when-let [news-url @(subscribe [:current-mine/news])]
+        [link news-url
+         [poppable {:data [:span "Read our blog"]
+                    :children [icon "blog" 2]}]])
+      (when-let [twitter-url @(subscribe [:current-mine/url :twitter])]
+        [link twitter-url
+         [poppable {:data [:span "Follow us on Twitter"]
+                    :children [icon "twitter" 2]}]])
+      (when-let [discord-url @(subscribe [:current-mine/url :discord])]
+        [link discord-url
+         [poppable {:data [:span "Chat with us on Discord"]
+                    :children [icon "discord" 2]}]])]
      [:div.section.column
-      [link mine-citation
-       (str "CITE " (some-> mine-name str/upper-case))]
-      [link "http://intermine.org/about-intermine/" "ABOUT US"]
-      [link "http://intermine.org/privacy-policy/" "PRIVACY POLICY"]]]))
+      [link @(subscribe [:current-mine/citation])
+       (str "CITE " (some-> @(subscribe [:current-mine-human-name]) str/upper-case))]
+      [link @(subscribe [:current-mine/url :aboutUs]) "ABOUT US"]
+      [link @(subscribe [:current-mine/url :privacyPolicy]) "PRIVACY POLICY"]]]))

--- a/src/cljs/bluegenes/error.cljs
+++ b/src/cljs/bluegenes/error.cljs
@@ -8,18 +8,13 @@
             [cljs-time.format :refer [unparse formatters]]
             [bluegenes.config :refer [server-vars]]))
 
-;; This email is used if no maintainerEmail is available, or when we wish to
-;; CC support (ie. when the failure is caused by a software problem).
-(def support-email "support@intermine.org")
-
 (defn mailto-string [error]
-  (let [maintainer-email (or @(subscribe [:registry/email]) support-email)
+  (let [support-email (or @(subscribe [:current-mine/support-email]) "support@intermine.org")
         current-url (oget js/window :location :href)
         service-url (get-in @(subscribe [:current-mine]) [:service :root])
         current-date (unparse (formatters :rfc822) (time/now))]
-    (str "mailto:" maintainer-email
+    (str "mailto:" support-email
          "?subject=" (gstring/urlEncode "[BLUEGENES] - Uncaught error")
-         "&cc=" support-email
          "&body=" (gstring/urlEncode
                    (str "Description:
 

--- a/src/cljs/bluegenes/events/webproperties.cljs
+++ b/src/cljs/bluegenes/events/webproperties.cljs
@@ -43,7 +43,7 @@
                                       (map string/trim)
                                       (first))
    :regionsearch-example         (get-in web-properties [:genomicRegionSearch :defaultSpans])
-   :news                         (or (get-in web-properties [:project :news]) "https://intermineorg.wordpress.com/")
+   :news                         (get-in web-properties [:project :news])
    :rss                          (get-in web-properties [:project :rss])
    :citation                     (or (parse-citation (get-in web-properties [:project :citation])) "http://intermine.org/publications/")
    :credits                      (parse-credits (get-in web-properties [:project :credit]))
@@ -61,7 +61,12 @@
                                                       (assoc m (capitalize-kw k) v))
                                                     {} ids)
                                          (rename-keys {:Default :Gene}))
-                                     {:Gene ids}))})
+                                     {:Gene ids}))
+   :url (merge {:tutorial "http://intermine.org/intermine-user-docs/"
+                :aboutUs "http://intermine.org/about-intermine/"
+                :privacyPolicy "http://intermine.org/privacy-policy/"}
+               (get-in web-properties [:project :url]))
+   :support-email (get-in web-properties [:project :supportEmail])})
 ;   :default-query-example        {;;we need json queries to use the endpoint properly
                                   ;;https://github.com/intermine/intermine/issues/1770
                                   ;;note that the default query button won't appear

--- a/src/cljs/bluegenes/events/webproperties.cljs
+++ b/src/cljs/bluegenes/events/webproperties.cljs
@@ -62,8 +62,7 @@
                                                     {} ids)
                                          (rename-keys {:Default :Gene}))
                                      {:Gene ids}))
-   :url (merge {:tutorial "http://intermine.org/intermine-user-docs/"
-                :aboutUs "http://intermine.org/about-intermine/"
+   :url (merge {:aboutUs "http://intermine.org/about-intermine/"
                 :privacyPolicy "http://intermine.org/privacy-policy/"}
                (get-in web-properties [:project :url]))
    :support-email (get-in web-properties [:project :supportEmail])})

--- a/src/cljs/bluegenes/events/webproperties.cljs
+++ b/src/cljs/bluegenes/events/webproperties.cljs
@@ -20,17 +20,18 @@
         ;; Otherwise, extract it from the href attribute.
         (second (re-find #"href=[\"']([^\"']+)" cit)))))
 
-(defn parse-credits
-  "Converts a web property credits object with numbered keys and object values
-  to a vector of maps."
-  [credits]
-  (if (s/valid? :bluegenes.webproperties.project/credit credits)
-    (->> credits
+(defn parse-numbered-properties
+  "Converts a web property object with numbered keys and object values to a
+  vector of maps in the correct order."
+  [object spec web-property-path]
+  (if (s/valid? spec object)
+    (->> object
          (map (juxt (comp js/parseInt name key) val))
          (into (sorted-map))
          (vals)
          (vec))
-    (do (.error js/console (str "Invalid web property project.credit: " (s/explain-str :bluegenes.webproperties.project/credit credits)))
+    (do (.error js/console
+                (str "Invalid web property " web-property-path ": " (s/explain-str spec object)))
         nil)))
 
 (defn web-properties-to-bluegenes
@@ -46,7 +47,9 @@
    :news                         (get-in web-properties [:project :news])
    :rss                          (get-in web-properties [:project :rss])
    :citation                     (or (parse-citation (get-in web-properties [:project :citation])) "http://intermine.org/publications/")
-   :credits                      (parse-credits (get-in web-properties [:project :credit]))
+   :credits                      (parse-numbered-properties (get-in web-properties [:project :credit])
+                                                            :bluegenes.webproperties.project/credit
+                                                            "project.credit")
    :oauth2-providers             (set (get-in web-properties [:oauth2_providers]))
    :idresolver-example           (let [ids (get-in web-properties [:bag :example :identifiers])]
                                    ;; ids can be one of the following:
@@ -65,13 +68,20 @@
    :url (merge {:aboutUs "http://intermine.org/about-intermine/"
                 :privacyPolicy "http://intermine.org/privacy-policy/"}
                (get-in web-properties [:project :url]))
-   :support-email (get-in web-properties [:project :supportEmail])})
+
+   :support-email (get-in web-properties [:project :supportEmail])
+
+   :customisation (-> (clojure.walk/postwalk #(case % "true" true "false" false %)
+                                             (:bluegenes web-properties))
+                      (update-in [:homepage :cta] parse-numbered-properties
+                                 :bluegenes.webproperties.customisation.homepage/cta
+                                 "bluegenes.homepage.cta"))})
+
 ;   :default-query-example        {;;we need json queries to use the endpoint properly
                                   ;;https://github.com/intermine/intermine/issues/1770
                                   ;;note that the default query button won't appear
                                   ;;until we fix this issue
                                 ;}
-
 
 ; Fetch web properties
 (reg-event-db

--- a/src/cljs/bluegenes/pages/home/subs.cljs
+++ b/src/cljs/bluegenes/pages/home/subs.cljs
@@ -1,5 +1,5 @@
 (ns bluegenes.pages.home.subs
-  (:require [re-frame.core :refer [reg-sub]]
+  (:require [re-frame.core :refer [reg-sub subscribe]]
             [clojure.string :as str]
             [bluegenes.events.blog :refer [get-rss-from-db]]))
 
@@ -70,3 +70,22 @@
  (fn [db]
    (let [rss (get-rss-from-db db)]
      (get-in db [:cache :rss rss]))))
+
+(reg-sub
+ :home/customisations
+ :<- [:current-mine/customisation]
+ (fn [custom]
+   (:homepage custom)))
+
+(reg-sub
+ :home/customisation
+ :<- [:home/customisations]
+ (fn [home [_ kw]]
+   (get home kw)))
+
+(reg-sub
+ :home/custom-cta
+ (fn [_]
+   (subscribe [:home/customisation :cta]))
+ (fn [cta]
+   cta))

--- a/src/cljs/bluegenes/pages/home/views.cljs
+++ b/src/cljs/bluegenes/pages/home/views.cljs
@@ -119,7 +119,7 @@
     [:p [:strong "Contact us"] " with problems, comments, suggestions and any other queries."]]
    [:div.col-xs-12.col-sm-5.cta-block
     [:a.btn.btn-home
-     {:href @(subscribe [:current-mine/news])
+     {:href (or @(subscribe [:current-mine/news]) "https://intermineorg.wordpress.com/")
       :target "_blank"}
      "What's new"]
     [latest-news]]

--- a/src/cljs/bluegenes/pages/home/views.cljs
+++ b/src/cljs/bluegenes/pages/home/views.cljs
@@ -22,21 +22,24 @@
         release @(subscribe [:current-mine/release])]
     [:div.row.section.mine-intro
      [:div.col-xs-10.col-xs-offset-1
-      [:h2.text-center.text-uppercase.mine-name mine-name]
-      [:div.mine-release
-       ;; Only prepend 'v' if release starts with a digit.
-       (cond->> release
-         (some->> release (re-find #"^\d")) (str "v"))]
-      [:div.mine-description
-       (md-paragraph description)]
+      (when-not @(subscribe [:home/customisation :hideMineIntro])
+        [:<>
+         [:h2.text-center.text-uppercase.mine-name mine-name]
+         [:div.mine-release
+          ;; Only prepend 'v' if release starts with a digit.
+          (cond->> release
+            (some->> release (re-find #"^\d")) (str "v"))]
+         [:div.mine-description
+          (md-paragraph description)]])
       (when notice
         [:div.well.well-sm.well-warning.text-center
          [md-element notice]])
-      [:div.search
-       [search/main]
-       [:div.search-info
-        [icon "info"]
-        [:span "Genes, proteins, pathways, ontology terms, authors, etc."]]]]]))
+      (when-not @(subscribe [:home/customisation :hideSearch])
+        [:div.search
+         [search/main]
+         [:div.search-info
+          [icon "info"]
+          [:span "Genes, proteins, pathways, ontology terms, authors, etc."]]])]]))
 
 (defn template-queries []
   (let [categories @(subscribe [:templates-by-popularity/all-categories])
@@ -80,55 +83,66 @@
                [:a {:href link :target "_blank"} title]
                [:p (-> description gstring/unescapeEntities str/trim (subs 0 100))]])))))
 
+(defn convert-custom-cta
+  "Convert the custom CTA format used in web.properties to the one used for rendering."
+  [{:keys [label text]
+    route-value :route dispatch-value :dispatch url-value :url}]
+  {:label label
+   :props (cond
+            route-value {:href (route/href (keyword "bluegenes.route" route-value))}
+            dispatch-value {:on-click #(dispatch [(keyword dispatch-value)])
+                            :role "button"}
+            url-value {:href url-value
+                       :target "_blank"})
+   :body (md-paragraph text)})
+
+;; This MUST be a function, as otherwise `route/href` would get invoked when
+;; the namespace is required, which depends on a subscription which might not
+;; be registered in time, causing a crash.
+(defn default-cta []
+  [{:label "Analyse data"
+    :props {:href (route/href ::route/upload)}
+    :body [:p [:strong "Upload"] " your own sets of genes, proteins, transcripts or other data type to analyse against the integrated data."]}
+   {:label "Browse sources"
+    :props {:on-click #(dispatch [:home/query-data-sources])
+            :role "button"}
+    :body [:p "Browse the full set of data available including versions, publications and links to the " [:strong "original data"] "."]}
+   {:label "Build your own query"
+    :props {:href (route/href ::route/querybuilder)}
+    :body [:p "The " [:strong "Query Builder"] " allows you to select and combine data classes, apply filters and configure the result table.  For a full set of pre-built searches, see the " [:a {:href (route/href ::route/templates)} "Templates"] "."]}
+   {:label "Tutorials"
+    :props {:href "http://intermine.org/intermine-user-docs/"
+            :target "_blank"}
+    :body [:p "Learn more about InterMine and how to search and analyse the data with a comprehensive set of " [:strong "written and video tutorials"] ".  Please " [:a {:on-click #(dispatch [:home/scroll-to-feedback]) :role "button"} "contact us"] " if you can’t find what you need!"]}
+   {:label "Web services"
+    :props {:href "http://intermine.org/im-docs/docs/web-services/index"
+            :target "_blank"}
+    :body [:p "The " [:strong "InterMine API"] " has language bindings for Perl, Python, Ruby and Java, allowing you to easily run queries directly from scripts.  All queries available in the user interface can also be run through the API with results being returned in a number of formats."]}
+   {:label "Submit feedback"
+    :props {:on-click #(dispatch [:home/scroll-to-feedback])
+            :role "button"}
+    :body [:p [:strong "Contact us"] " with problems, comments, suggestions and any other queries."]}
+   {:label "What's new"
+    :props {:href (or @(subscribe [:current-mine/news]) "https://intermineorg.wordpress.com/")
+            :target "_blank"}
+    :body [latest-news]}
+   {:label "Cite us"
+    :props {:href @(subscribe [:current-mine/citation])
+            :target "_blank"}
+    :body [:p "Please help us to maintain funding: if we have helped your research please remember to cite us in your publications."]}])
+
 (defn call-to-action []
-  [:div.row.section.grid ;; Without grid class the 3rd row won't be on the same row.
-   ;; This isn't official bootstrap, so I can only imagine Gridlex is messing with things.
-   [:div.col-xs-12.col-sm-5.cta-block
-    [:a.btn.btn-home
-     {:href (route/href ::route/upload)}
-     "Analyse data"]
-    [:p [:strong "Upload"] " your own sets of genes, proteins, transcripts or other data type to analyse against the integrated data."]]
-   [:div.col-xs-12.col-sm-5.col-sm-offset-2.cta-block
-    [:a.btn.btn-home
-     {:on-click #(dispatch [:home/query-data-sources])
-      :role "button"}
-     "Browse sources"]
-    [:p "Browse the full set of data available including versions, publications and links to the " [:strong "original data"] "."]]
-   [:div.col-xs-12.col-sm-5.cta-block
-    [:a.btn.btn-home
-     {:href (route/href ::route/querybuilder)}
-     "Build your own query"]
-    [:p "The " [:strong "Query Builder"] " allows you to select and combine data classes, apply filters and configure the result table.  For a full set of pre-built searches, see the " [:a {:href (route/href ::route/templates)} "Templates"] "."]]
-   [:div.col-xs-12.col-sm-5.col-sm-offset-2.cta-block
-    [:a.btn.btn-home
-     {:href "http://intermine.org/intermine-user-docs/"
-      :target "_blank"}
-     "Tutorials"]
-    [:p "Learn more about InterMine and how to search and analyse the data with a comprehensive set of " [:strong "written and video tutorials"] ".  Please " [:a {:on-click #(dispatch [:home/scroll-to-feedback]) :role "button"} "contact us"] " if you can’t find what you need!"]]
-   [:div.col-xs-12.col-sm-5.cta-block
-    [:a.btn.btn-home
-     {:href "http://intermine.org/im-docs/docs/web-services/index"
-      :target "_blank"}
-     "Web services"]
-    [:p "The " [:strong "InterMine API"] " has language bindings for Perl, Python, Ruby and Java, allowing you to easily run queries directly from scripts.  All queries available in the user interface can also be run through the API with results being returned in a number of formats."]]
-   [:div.col-xs-12.col-sm-5.col-sm-offset-2.cta-block
-    [:a.btn.btn-home
-     {:on-click #(dispatch [:home/scroll-to-feedback])
-      :role "button"}
-     "Submit feedback"]
-    [:p [:strong "Contact us"] " with problems, comments, suggestions and any other queries."]]
-   [:div.col-xs-12.col-sm-5.cta-block
-    [:a.btn.btn-home
-     {:href (or @(subscribe [:current-mine/news]) "https://intermineorg.wordpress.com/")
-      :target "_blank"}
-     "What's new"]
-    [latest-news]]
-   [:div.col-xs-12.col-sm-5.col-sm-offset-2.cta-block
-    [:a.btn.btn-home
-     {:href @(subscribe [:current-mine/citation])
-      :target "_blank"}
-     "Cite us"]
-    [:p "Please help us to maintain funding: if we have helped your research please remember to cite us in your publications."]]])
+  (let [custom-cta @(subscribe [:home/custom-cta])
+        cta (if (seq custom-cta)
+              (map convert-custom-cta custom-cta)
+              (default-cta))]
+    (into [:div.row.section.grid] ;; Without grid class the 3rd row won't be on the same row.
+           ;; This isn't official bootstrap, so I can only imagine Gridlex is messing with things.
+          (for [[index {:keys [label props body]}] (map-indexed vector cta)]
+            [:div.col-xs-12.col-sm-5.cta-block
+             {:class (when (odd? index) :col-sm-offset-2)}
+             [:a.btn.btn-home props label]
+             body]))))
 
 (defn mine-selector-filter []
   (let [all-neighbourhoods @(subscribe [:home/all-registry-mine-neighbourhoods])
@@ -313,9 +327,9 @@
 (defn main []
   [:div.container.home
    [mine-intro]
-   [template-queries]
-   [call-to-action]
-   [mine-selector]
-   [external-tools]
-   [feedback]
-   [credits]])
+   (when-not @(subscribe [:home/customisation :hideTemplateQueries]) [template-queries])
+   (when-not @(subscribe [:home/customisation :hideCTA]) [call-to-action])
+   (when-not @(subscribe [:home/customisation :hideMineSelector]) [mine-selector])
+   (when-not @(subscribe [:home/customisation :hideAlternativeTools]) [external-tools])
+   (when-not @(subscribe [:home/customisation :hideFeedback]) [feedback])
+   (when-not @(subscribe [:home/customisation :hideCredits]) [credits])])

--- a/src/cljs/bluegenes/specs.cljs
+++ b/src/cljs/bluegenes/specs.cljs
@@ -20,7 +20,6 @@
 (s/def :bluegenes.webproperties.project/credit (s/or :empty ::empty-non-string
                                                      :map (s/map-of ::integer-keyword :bluegenes.webproperties.project.credit/item)))
 
-
 (s/def :bluegenes.webproperties.customisation.homepage.cta.item/label string?)
 (s/def :bluegenes.webproperties.customisation.homepage.cta.item/text string?)
 

--- a/src/cljs/bluegenes/specs.cljs
+++ b/src/cljs/bluegenes/specs.cljs
@@ -20,6 +20,33 @@
 (s/def :bluegenes.webproperties.project/credit (s/or :empty ::empty-non-string
                                                      :map (s/map-of ::integer-keyword :bluegenes.webproperties.project.credit/item)))
 
+
+(s/def :bluegenes.webproperties.customisation.homepage.cta.item/label string?)
+(s/def :bluegenes.webproperties.customisation.homepage.cta.item/text string?)
+
+(s/def :bluegenes.webproperties.customisation.homepage.cta.item/route string?)
+(s/def :bluegenes.webproperties.customisation.homepage.cta.item/dispatch string?)
+(s/def :bluegenes.webproperties.customisation.homepage.cta.item/url string?)
+
+(s/def :bluegenes.webproperties.customisation.homepage.cta/route (s/keys :req-un [:bluegenes.webproperties.customisation.homepage.cta.item/label
+                                                                                  :bluegenes.webproperties.customisation.homepage.cta.item/route
+                                                                                  :bluegenes.webproperties.customisation.homepage.cta.item/text]))
+
+(s/def :bluegenes.webproperties.customisation.homepage.cta/dispatch (s/keys :req-un [:bluegenes.webproperties.customisation.homepage.cta.item/label
+                                                                                     :bluegenes.webproperties.customisation.homepage.cta.item/dispatch
+                                                                                     :bluegenes.webproperties.customisation.homepage.cta.item/text]))
+
+(s/def :bluegenes.webproperties.customisation.homepage.cta/url (s/keys :req-un [:bluegenes.webproperties.customisation.homepage.cta.item/label
+                                                                                :bluegenes.webproperties.customisation.homepage.cta.item/url
+                                                                                :bluegenes.webproperties.customisation.homepage.cta.item/text]))
+
+(s/def :bluegenes.webproperties.customisation.homepage.cta/item (s/or :route :bluegenes.webproperties.customisation.homepage.cta/route
+                                                                      :dispatch :bluegenes.webproperties.customisation.homepage.cta/dispatch
+                                                                      :url :bluegenes.webproperties.customisation.homepage.cta/url))
+
+(s/def :bluegenes.webproperties.customisation.homepage/cta (s/or :empty ::empty-non-string
+                                                                 :map (s/map-of ::integer-keyword :bluegenes.webproperties.customisation.homepage.cta/item)))
+
 ;;;; Below is old!
 
 ; Note: It's really worth revisiting this in the future. Creating specs for InterMine

--- a/src/cljs/bluegenes/subs.cljs
+++ b/src/cljs/bluegenes/subs.cljs
@@ -208,6 +208,24 @@
    (:oauth2-providers current-mine)))
 
 (reg-sub
+ :current-mine/support-email
+ :<- [:current-mine]
+ (fn [current-mine]
+   (:support-email current-mine)))
+
+(reg-sub
+ :current-mine/urls
+ :<- [:current-mine]
+ (fn [current-mine]
+   (:url current-mine)))
+
+(reg-sub
+ :current-mine/url
+ :<- [:current-mine/urls]
+ (fn [urls [_ kw]]
+   (get urls kw)))
+
+(reg-sub
  :current-mine/notice
  :<- [:current-mine]
  (fn [current-mine]
@@ -335,20 +353,6 @@
  :<- [:current-mine-name]
  (fn [[registry current-mine]]
    (get-in registry [current-mine :description])))
-
-(reg-sub
- :registry/twitter
- :<- [:registry]
- :<- [:current-mine-name]
- (fn [[registry current-mine]]
-   (not-empty (get-in registry [current-mine :twitter]))))
-
-(reg-sub
- :registry/email
- :<- [:registry]
- :<- [:current-mine-name]
- (fn [[registry current-mine]]
-   (not-empty (get-in registry [current-mine :maintainerEmail]))))
 
 ;;;; Branding
 

--- a/src/cljs/bluegenes/subs.cljs
+++ b/src/cljs/bluegenes/subs.cljs
@@ -226,6 +226,12 @@
    (get urls kw)))
 
 (reg-sub
+ :current-mine/customisation
+ :<- [:current-mine]
+ (fn [current-mine]
+   (:customisation current-mine)))
+
+(reg-sub
  :current-mine/notice
  :<- [:current-mine]
  (fn [current-mine]


### PR DESCRIPTION
This is achieved by introducing the following new keys to `web.properties`:

```properties
# Will hide email icon in footer if not defined, but CTA will default to
# InterMine blog (use hideCTA or define custom cta to override this).
project.news = http://intermineorg.wordpress.org
# Will default to InterMine blog RSS if not defined; used for CTA (can be
# overridden similarly to project.news).
project.rss = https://intermineorg.wordpress.com/feed/
# The two properties below will default to their current values if not defined
# (used for footer links).
project.url.aboutUs = http://intermine.org/about-intermine/
project.url.privacyPolicy = http://intermine.org/privacy-policy/

# Will hide their respective icons in footer if not defined.
project.url.github = https://github.com/intermine/
project.url.discord = http://chat.intermine.org/
project.url.twitter = https://twitter.com/intermineorg
project.supportEmail = support@intermine.org

# These properties can be used to hide their respective elements on the home page.
bluegenes.homepage.hideMineIntro = true
bluegenes.homepage.hideSearch = true
bluegenes.homepage.hideTemplateQueries = true
bluegenes.homepage.hideCTA = false
bluegenes.homepage.hideMineSelector = true
bluegenes.homepage.hideAlternativeTools = true
bluegenes.homepage.hideFeedback = true
bluegenes.homepage.hideCredits = true

# You can override the default CTA elements by defining your own. There are 3
# formats accepted. They all take label (string) and text (string with markdown
# supported, wherein the first paragraph will be extracted) in addition to one
# more property defining their action when clicked.

# Used for linking to pages inside Bluegenes: route is a :name in
# bluegenes.route/routes that takes no parameters.
bluegenes.homepage.cta.1.label = Upload identifiers
bluegenes.homepage.cta.1.route = upload
bluegenes.homepage.cta.1.text = **Upload** your own sets of genes.

# Used for performing actions in Bluegenes: dispatch is an event handler
# defined with reg-event-fx within Bluegenes that takes no arguments.
bluegenes.homepage.cta.2.label = Browse datasets
bluegenes.homepage.cta.2.dispatch = home/query-data-sources
bluegenes.homepage.cta.2.text = *Browse* the full set of data.

# Used for linking to external pages: url will be used for a link that opens it
# in a new tab.
bluegenes.homepage.cta.3.label = Documentation
bluegenes.homepage.cta.3.url = http://intermine.org/intermine-user-docs/
bluegenes.homepage.cta.3.text = Learn how to use Xmine.

```

Fixes #753
Fixes  #718
