### PR TITLE
Linking in to ID resolver with portal.do endpoint

### DIFF
--- a/src/clj/bluegenes/routes.clj
+++ b/src/clj/bluegenes/routes.clj
@@ -80,21 +80,21 @@
       ;; Linking in.
       ;; Handles both configured mines and the /query path.
       (wrap-params
-        (wrap-keyword-params
-          (apply compojure/routes
-                 (for [path (concat (map :namespace mines) ["query"])
-                       :let [redirect-path (str (:bluegenes-deploy-path env) "/"
-                                                (when-not (= path "query")
-                                                  path))]]
-                   (context (str "/" path) []
-                     (GET "/portal.do" {params :params}
-                        (-> (found redirect-path)
-                            (assoc :session {:init {:linkIn {:target :upload
-                                                             :data params}}})))
-                     (POST "/portal.do" {params :params}
-                       (-> (found redirect-path)
-                           (assoc :session {:init {:linkIn {:target :upload
-                                                            :data params}}}))))))))
+       (wrap-keyword-params
+        (apply compojure/routes
+               (for [path (concat (map :namespace mines) ["query"])
+                     :let [redirect-path (str (:bluegenes-deploy-path env) "/"
+                                              (when-not (= path "query")
+                                                path))]]
+                 (context (str "/" path) []
+                   (GET "/portal.do" {params :params}
+                     (-> (found redirect-path)
+                         (assoc :session {:init {:linkIn {:target :upload
+                                                          :data params}}})))
+                   (POST "/portal.do" {params :params}
+                     (-> (found redirect-path)
+                         (assoc :session {:init {:linkIn {:target :upload
+                                                          :data params}}}))))))))
 
       ;; Dynamic routes for handling permanent URL resolution on configured mines.
       (apply compojure/routes

--- a/src/cljs/bluegenes/components/idresolver/events.cljs
+++ b/src/cljs/bluegenes/components/idresolver/events.cljs
@@ -63,7 +63,6 @@
    (let [service (get-in db [:mines (get db :current-mine) :service])]
      {:db (-> db
               (assoc-in [:idresolver :stage :view] :review)
-              (assoc-in [:idresolver :stage :options :review-tab] :matches)
               (update :idresolver dissoc :response :error))
       :im-chan {:chan (fetch/resolve-identifiers service body)
                 :on-success [::store-identifiers type extra]

--- a/src/cljs/bluegenes/components/idresolver/events.cljs
+++ b/src/cljs/bluegenes/components/idresolver/events.cljs
@@ -232,7 +232,7 @@
                                       :op "IN"
                                       :value list-name}]}}]
                    ; Clear upload page state
-                   [::reset]]})))
+                   ^:flush-dom [::reset]]})))
 
 (reg-event-fx
  ::save-list-failure
@@ -289,3 +289,17 @@
                                 [:Gene gene-example]
                                 (first ids))]
      {:dispatch [::reset (name class-type) example]})))
+
+(reg-event-fx
+ ::redirect-missing-resolution
+ (fn [{db :db} [_]]
+   (let [resolution-response (get-in db [:idresolver :response])
+         resolution-error (get-in db [:idresolver :error])
+         parsing? (= (get-in db [:idresolver :stage :status :action]) :parsing)
+         parsed? (boolean (get-in db [:idresolver :stage :flags :parsed]))]
+     (if (and (empty? resolution-response)
+              (empty? resolution-error)
+              (not parsing?)
+              (not parsed?))
+       {:dispatch [::route/navigate ::route/upload-step {:step "input"}]}
+       {}))))

--- a/src/cljs/bluegenes/components/idresolver/events.cljs
+++ b/src/cljs/bluegenes/components/idresolver/events.cljs
@@ -218,7 +218,9 @@
                  [:assets :summary-fields
                   (get db :current-mine) (keyword object-type)])]
      {:db db
-      :dispatch-n [; Re-fetch our lists so that it shows in Lists page
+      :dispatch-n [; Clear upload page state
+                   [::reset]
+                   ; Re-fetch our lists so that it shows in Lists page
                    [:assets/fetch-lists]
                    ; Show the list results in the Results page
                    [:results/history+

--- a/src/cljs/bluegenes/components/idresolver/events.cljs
+++ b/src/cljs/bluegenes/components/idresolver/events.cljs
@@ -218,9 +218,7 @@
                  [:assets :summary-fields
                   (get db :current-mine) (keyword object-type)])]
      {:db db
-      :dispatch-n [; Clear upload page state
-                   [::reset]
-                   ; Re-fetch our lists so that it shows in Lists page
+      :dispatch-n [; Re-fetch our lists so that it shows in Lists page
                    [:assets/fetch-lists]
                    ; Show the list results in the Results page
                    [:results/history+
@@ -232,7 +230,9 @@
                              :select summary-fields
                              :where [{:path object-type
                                       :op "IN"
-                                      :value list-name}]}}]]})))
+                                      :value list-name}]}}]
+                   ; Clear upload page state
+                   [::reset]]})))
 
 (reg-event-fx
  ::save-list-failure

--- a/src/cljs/bluegenes/components/idresolver/events.cljs
+++ b/src/cljs/bluegenes/components/idresolver/events.cljs
@@ -59,14 +59,14 @@
 
 (reg-event-fx
  ::resolve-identifiers
- (fn [{db :db} [_ body]]
+ (fn [{db :db} [_ {:keys [type extra] :as body}]]
    (let [service (get-in db [:mines (get db :current-mine) :service])]
      {:db (-> db
               (assoc-in [:idresolver :stage :view] :review)
               (assoc-in [:idresolver :stage :options :review-tab] :matches)
               (update :idresolver dissoc :response :error))
       :im-chan {:chan (fetch/resolve-identifiers service body)
-                :on-success [::store-identifiers]
+                :on-success [::store-identifiers type extra]
                 :on-failure [::resolve-identifiers-failure]}})))
 
 (reg-event-db
@@ -95,13 +95,12 @@
 (reg-event-fx
  ::store-identifiers
  (datetime)
- (fn [{db :db now :datetime} [_ response]]
-   (let [{:keys [type organism]} (get-in db [:idresolver :stage :options])]
-     {:db (-> db
-              (assoc-in [:idresolver :response] response)
-              (assoc-in [:idresolver :stage :view] :review)
-              (assoc-in [:idresolver :save :list-name]
-                        (default-list-name type organism now)))})))
+ (fn [{db :db now :datetime} [_ type extra response]]
+   {:db (-> db
+            (assoc-in [:idresolver :response] response)
+            (assoc-in [:idresolver :stage :view] :review)
+            (assoc-in [:idresolver :save :list-name]
+                      (default-list-name type extra now)))}))
 
 (reg-event-db
  ::set-view

--- a/src/cljs/bluegenes/components/idresolver/subs.cljs
+++ b/src/cljs/bluegenes/components/idresolver/subs.cljs
@@ -53,10 +53,12 @@
          (fn [db]
            (get-in db [:idresolver :stage :view])))
 
+;; Note: When making changes to this, make the same change in :bluegenes.components.idresolver.events/redirect-missing-resolution
 (reg-sub ::parsing?
          (fn [db]
            (= (get-in db [:idresolver :stage :status :action]) :parsing)))
 
+;; Note: When making changes to this, make the same change in :bluegenes.components.idresolver.events/redirect-missing-resolution
 (reg-sub ::parsed?
          (fn [db]
            (boolean (get-in db [:idresolver :stage :flags :parsed]))))

--- a/src/cljs/bluegenes/components/idresolver/views.cljs
+++ b/src/cljs/bluegenes/components/idresolver/views.cljs
@@ -402,8 +402,11 @@
         list-name (subscribe [::subs/list-name])
         tab (subscribe [::subs/review-tab])
         stats (subscribe [::subs/stats])]
-    (when (pos? (:duplicates @stats))
-      (dispatch [::evts/update-option :review-tab :issues]))
+    ;; Select first tab with results.
+    (when-let [stats @stats]
+      (dispatch [::evts/update-option :review-tab
+                 (some #(when (pos? (get stats %)) %)
+                       [:matches :converted :other :issues :notFound])]))
     (fn [& {:keys [upgrade?]}]
       (let [{:keys [matches issues notFound converted duplicates all other]} @stats]
         [:div

--- a/src/cljs/bluegenes/db.cljc
+++ b/src/cljs/bluegenes/db.cljc
@@ -14,13 +14,16 @@
    :search {:selected-results #{}}
    :idresolver {:stage {:files nil
                         :textbox nil
-                        :options {:case-sensitive false}
+                        :options {:case-sensitive false
+                                  :type "Gene"
+                                  :organism nil}
                         :status nil
                         :flags nil}
                 :to-resolve {:total nil
                              :identifiers []}
                 :save {:list-name nil}
-                :response nil}
+                :response nil
+                :error nil}
    ;; If you change this, you should change `remove-stateful-keys-from-db` too.
    :lists {:pagination {:per-page 20
                         :current-page 1}

--- a/src/cljs/bluegenes/events/boot.cljs
+++ b/src/cljs/bluegenes/events/boot.cljs
@@ -584,8 +584,7 @@
                    {:case-sensitive false
                     :type (or (:class data)
                               (-> default-object-types first name))
-                    :organism (:extraValue data)
-                    :review-tab :matches}])}))))
+                    :organism (:extraValue data)}])}))))
 
 (reg-event-fx
  :assets/failure

--- a/src/cljs/bluegenes/events/boot.cljs
+++ b/src/cljs/bluegenes/events/boot.cljs
@@ -408,10 +408,12 @@
    ;; this turned out to be a very bad idea! This is because the model is used
    ;; to parse paths into classes, which means it has to be complete. This also
    ;; applies to the model hierarchy.
-   (-> db
-       (assoc-in [:mines mine-kw :service :model] model)
-       (assoc-in [:mines mine-kw :default-object-types] (sort (preferred-fields model)))
-       (assoc-in [:mines mine-kw :model-hier] (extends-hierarchy (:classes model))))))
+   (let [default-object-types (sort (preferred-fields model))]
+     (-> db
+         (assoc-in [:mines mine-kw :service :model] model)
+         (assoc-in [:mines mine-kw :default-object-types] default-object-types)
+         (assoc-in [:idresolver :stage :options :type] (-> default-object-types first name))
+         (assoc-in [:mines mine-kw :model-hier] (extends-hierarchy (:classes model)))))))
 
 (reg-event-fx
  :assets/fetch-model

--- a/src/cljs/bluegenes/events/boot.cljs
+++ b/src/cljs/bluegenes/events/boot.cljs
@@ -570,7 +570,7 @@
 (reg-event-fx
  :handle-link-in
  (fn [{db :db} [_ {:keys [target data]}]]
-   (let [{:keys [default-object-types default-organism]} (get-in db [:mines (:current-mine db)])]
+   (let [{:keys [default-object-types]} (get-in db [:mines (:current-mine db)])]
      (case target
        :upload {:dispatch
                 (if (str/blank? (:externalids data))
@@ -584,8 +584,7 @@
                    {:case-sensitive false
                     :type (or (:class data)
                               (-> default-object-types first name))
-                    :organism (or (:extraValue data)
-                                  default-organism)
+                    :organism (:extraValue data)
                     :review-tab :matches}])}))))
 
 (reg-event-fx

--- a/src/cljs/bluegenes/events/boot.cljs
+++ b/src/cljs/bluegenes/events/boot.cljs
@@ -584,7 +584,7 @@
                    {:case-sensitive false
                     :type (or (:class data)
                               (-> default-object-types first name))
-                    :organism (or (:organism data)
+                    :organism (or (:extraValue data)
                                   default-organism)
                     :review-tab :matches}])}))))
 

--- a/src/cljs/bluegenes/events/boot.cljs
+++ b/src/cljs/bluegenes/events/boot.cljs
@@ -572,15 +572,21 @@
  (fn [{db :db} [_ {:keys [target data]}]]
    (let [{:keys [default-object-types default-organism]} (get-in db [:mines (:current-mine db)])]
      (case target
-       :upload {:dispatch [:bluegenes.components.idresolver.events/parse-staged-files
-                           nil
-                           (:externalids data)
-                           {:case-sensitive false
-                            :type (or (:class data)
-                                      (-> default-object-types first name))
-                            :organism (or (:organism data)
-                                          default-organism)
-                            :review-tab :matches}]}))))
+       :upload {:dispatch
+                (if (str/blank? (:externalids data))
+                  [:messages/add
+                   {:markup [:span "No identifiers specified when linking in to upload page. You have been redirected to the home page."]
+                    :style "warning"
+                    :timeout 0}]
+                  [:bluegenes.components.idresolver.events/parse-staged-files
+                   nil
+                   (:externalids data)
+                   {:case-sensitive false
+                    :type (or (:class data)
+                              (-> default-object-types first name))
+                    :organism (or (:organism data)
+                                  default-organism)
+                    :review-tab :matches}])}))))
 
 (reg-event-fx
  :assets/failure

--- a/src/cljs/bluegenes/pages/upload/views.cljs
+++ b/src/cljs/bluegenes/pages/upload/views.cljs
@@ -343,8 +343,7 @@
             "Save"])]]])))
 
 (defn wizard []
-  (let [view (subscribe [::subs/view])
-        panel-params (subscribe [:panel-params])]
+  (let [panel-params (subscribe [:panel-params])]
     (fn []
       [:div.wizard
        [breadcrumbs (:step @panel-params)]
@@ -354,13 +353,7 @@
           [upload-step])]])))
 
 (defn main []
-  (let [options (subscribe [::subs/stage-options])]
-    (reagent/create-class
-     {:component-did-mount
-      (fn [e]
-        (attach-body-events)
-        (dispatch [::evts/reset]))
-      :reagent-render
-      (fn []
-        [:div.container.idresolverupload
-         [wizard]])})))
+  (attach-body-events)
+  (fn []
+    [:div.container.idresolverupload
+     [wizard]]))

--- a/src/cljs/bluegenes/pages/upload/views.cljs
+++ b/src/cljs/bluegenes/pages/upload/views.cljs
@@ -316,10 +316,7 @@
 
         (some? @resolution-response) [idresolver/main]
 
-        @in-progress? [:div.wizard-loader [loader "IDENTIFIERS"]]
-
-        ;; Side-effects in view are bad. This should be done from event handler instead.
-        :else (dispatch [::route/navigate ::route/upload-step {:step "input"}])))))
+        @in-progress? [:div.wizard-loader [loader "IDENTIFIERS"]]))))
 
 (defn breadcrumbs []
   (let [response (subscribe [::subs/resolution-response])]

--- a/src/cljs/bluegenes/route.cljs
+++ b/src/cljs/bluegenes/route.cljs
@@ -188,7 +188,9 @@
        [{:parameters {:path [:step]}
          :start (fn [{{:keys [step]} :path}]
                   (dispatch [:set-active-panel :upload-panel
-                             {:step (keyword step)}]))}]}]]
+                             {:step (keyword step)}])
+                  (when (= step "save")
+                    (dispatch [:bluegenes.components.idresolver.events/redirect-missing-resolution])))}]}]]
     ["/upgrade"
      {:name ::upgrade
       :controllers


### PR DESCRIPTION
Same API as the legacy portal.do documented here (sections with URLs including portal.do): https://intermine.readthedocs.io/en/latest/webapp/linking-in/#list-of-identifiers

A significant difference is that it doesn't automatically save the list (when ID resolution doesn't require manual intervention) and show the list analysis page; or show the report page when there's a single ID.

Fixes #735

