### PR TITLE
Remove script loading imjs from cdn

### DIFF
--- a/src/clj/bluegenes/index.clj
+++ b/src/clj/bluegenes/index.clj
@@ -121,7 +121,6 @@
   ; Javascript:
     ;; This favicon is dynamically served; see routes.clj.
     [:link {:href (use-deployment-path "/favicon.ico") :type "image/x-icon" :rel "shortcut icon"}]
-    [:script {:src "https://cdn.intermine.org/js/intermine/imjs/latest/im.min.js"}]
     [:script {:crossorigin "anonymous"
               :integrity "sha256-cCueBR6CsyA4/9szpPfrX3s49M9vUU5BgtiJj06wt/s="
               :src "https://code.jquery.com/jquery-3.1.0.min.js"}]


### PR DESCRIPTION
This is no longer available and doesn't seem like it's in use either (not referenced in code and doesn't break anything).

Removing it will speed up the page loading as it currently waits for it to timeout.