### PR TITLE
Create config subdirectories for dev and prod

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ executors:
     - image: 'circleci/clojure:openjdk-8-lein-2.9.1-node-browsers'
   intermine_exec:
     machine:
-      image: ubuntu-2004:202010-01
+      image: ubuntu-2004:2024.11.1
     environment:
       BLUEGENES_DEFAULT_SERVICE_ROOT: "http://localhost:9999/biotestmine"
       BLUEGENES_DEFAULT_MINE_NAME: Biotestmine

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ prepros.cfg
 /.lsp/
 /*.jks
 /.lein-env
+*~

--- a/config/dev/README.md
+++ b/config/dev/README.md
@@ -1,0 +1,1 @@
+Put config.edn in here

--- a/config/prod/README.md
+++ b/config/prod/README.md
@@ -1,0 +1,1 @@
+Put config.edn in here


### PR DESCRIPTION
The `.gitignore` file will ignore files like `config/dev/config.edn` and `config/prod/config.edn` but the `dev` and `prod` subdirectories don't exist in version control. This looks like an oversight.

This change ensures these directories are in git by including a `README.md` in each.
This change will also ignore Emacs backup files
